### PR TITLE
PR gh #77 : Fix release script for dunfell linux, cmake changes

### DIFF
--- a/scripts/release-test-script-ut-control.sh
+++ b/scripts/release-test-script-ut-control.sh
@@ -291,9 +291,9 @@ run_checks() {
         fi
     elif [[ "$environment" == "dunfell_linux" ]]; then
         if [ ! -f "$CMAKE_HOST_BIN" ]; then
-            echo -e "${GREEN}CMake host binary does not exist. PASS ${NC}"
+            echo -e "${RED}CMake host binary does not exist. FAIL ${NC}"
         else
-            echo -e "${RED}CMake host binary exists. FAIL ${NC}"
+            echo -e "${GREEN}CMake host binary exists. PASS ${NC}"
         fi
     elif [[ "$environment" == "kirkstone_arm" ]]; then
         if [ ! -f "$CMAKE_HOST_BIN" ]; then


### PR DESCRIPTION
With the recent changes in PR : https://github.com/rdkcentral/ut-control/pull/72, CMAKE gets build for docker dunfell with linux environment.
Release script needs modification for the same. This fix takes care of this modification. 