### PR TITLE
Modify source file to load curl library at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ INC_DIRS += ${TOP_DIR}/include
 
 XCFLAGS += -fPIC -Wall -shared   # Flags for compilation
 XCFLAGS += -DNDEBUG
-XCFLAGS += -DLIBCURL_PATH=\"$(LIBCURL_PATH)\"
 # CFLAGS += -DWEBSOCKET_SERVER
 
 MKDIR_P ?= @mkdir -p
@@ -92,10 +91,8 @@ ifeq ($(TARGET),arm)
 # CFLAGS will be overriden by Caller as required
 INC_DIRS += $(UT_DIR)/sysroot/usr/include
 XLDFLAGS += -ldl
-LIBCURL_PATH="/usr/lib/libcurl.so.4"
 else
 #linux case
-LIBCURL_PATH := $(shell find /usr/ -type l -iname "libcurl.so*" 2>/dev/null | head -n1)
 # Check if the directory exists
 ifneq ($(wildcard $(OPENSSL_LIB_DIR)),)
 XLDFLAGS += -ldl

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,8 @@ XLDFLAGS += $(LIBWEBSOCKETS_DIR)/lib/libwebsockets.a
 CURL_DIR = $(FRAMEWORK_BUILD_DIR)/curl
 ifneq ($(wildcard $(CURL_DIR)),)
 INC_DIRS += $(CURL_DIR)/include
-XLDFLAGS += $(CURL_DIR)/lib/libcurl.a
-else
-# Commands to run if the directory does not exist
-XLDFLAGS += -lcurl
 endif
+XLDFLAGS += -ldl
 
 # UT Control library Requirements
 SRC_DIRS += ${TOP_DIR}/src
@@ -80,6 +77,7 @@ INC_DIRS += ${TOP_DIR}/include
 
 XCFLAGS += -fPIC -Wall -shared   # Flags for compilation
 XCFLAGS += -DNDEBUG
+XCFLAGS += -DLIBCURL_PATH=\"$(LIBCURL_PATH)\"
 # CFLAGS += -DWEBSOCKET_SERVER
 
 MKDIR_P ?= @mkdir -p
@@ -93,12 +91,14 @@ ifeq ($(TARGET),arm)
 #CC := arm-rdk-linux-gnueabi-gcc -mthumb -mfpu=vfp -mcpu=cortex-a9 -mfloat-abi=soft -mabi=aapcs-linux -mno-thumb-interwork -ffixed-r8 -fomit-frame-pointer
 # CFLAGS will be overriden by Caller as required
 INC_DIRS += $(UT_DIR)/sysroot/usr/include
-XLDFLAGS += $(OPENSSL_LIB_DIR)/libssl.a $(OPENSSL_LIB_DIR)/libcrypto.a -ldl
+XLDFLAGS += -ldl
+LIBCURL_PATH="/usr/lib/libcurl.so.4"
 else
 #linux case
+LIBCURL_PATH="/usr/lib/x86_64-linux-gnu/libcurl.so.4"
 # Check if the directory exists
 ifneq ($(wildcard $(OPENSSL_LIB_DIR)),)
-XLDFLAGS += $(OPENSSL_LIB_DIR)/libssl.a $(OPENSSL_LIB_DIR)/libcrypto.a -ldl
+XLDFLAGS += -ldl
 else
 # Commands to run if the directory does not exist
 XLDFLAGS += -lssl -lcrypto
@@ -150,6 +150,7 @@ list:
 	@$(ECHOE) ${YELLOW}SRC_DIRS:${NC} ${SRC_DIRS}
 	@$(ECHOE) ${YELLOW}CFLAGS:${NC} ${CFLAGS}
 	@$(ECHOE) ${YELLOW}XLDFLAGS:${NC} ${XLDFLAGS}
+	@$(ECHOE) ${YELLOW}XCFLAGS:${NC} ${XCFLAGS}
 	@$(ECHOE) ${YELLOW}TARGET_LIB:${NC} ${TARGET_LIB}
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -90,16 +90,10 @@ ifeq ($(TARGET),arm)
 #CC := arm-rdk-linux-gnueabi-gcc -mthumb -mfpu=vfp -mcpu=cortex-a9 -mfloat-abi=soft -mabi=aapcs-linux -mno-thumb-interwork -ffixed-r8 -fomit-frame-pointer
 # CFLAGS will be overriden by Caller as required
 INC_DIRS += $(UT_DIR)/sysroot/usr/include
-XLDFLAGS += -ldl
 else
 #linux case
-# Check if the directory exists
-ifneq ($(wildcard $(OPENSSL_LIB_DIR)),)
-XLDFLAGS += -ldl
-else
 # Commands to run if the directory does not exist
 XLDFLAGS += -lssl -lcrypto
-endif
 endif
 
 # Defaults for target linux

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,6 @@ ifeq ($(TARGET),arm)
 #CC := arm-rdk-linux-gnueabi-gcc -mthumb -mfpu=vfp -mcpu=cortex-a9 -mfloat-abi=soft -mabi=aapcs-linux -mno-thumb-interwork -ffixed-r8 -fomit-frame-pointer
 # CFLAGS will be overriden by Caller as required
 INC_DIRS += $(UT_DIR)/sysroot/usr/include
-else
-#linux case
-# Commands to run if the directory does not exist
-XLDFLAGS += -lssl -lcrypto
 endif
 
 # Defaults for target linux

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ XLDFLAGS += -ldl
 LIBCURL_PATH="/usr/lib/libcurl.so.4"
 else
 #linux case
-LIBCURL_PATH="/usr/lib/x86_64-linux-gnu/libcurl.so.4"
+LIBCURL_PATH := $(shell find /usr/ -type l -iname "libcurl.so*" 2>/dev/null | head -n1)
 # Check if the directory exists
 ifneq ($(wildcard $(OPENSSL_LIB_DIR)),)
 XLDFLAGS += -ldl

--- a/configure.sh
+++ b/configure.sh
@@ -288,13 +288,13 @@ build_curl()
     mkdir -p ${CURL_BUILD_DIR}
     if [ "$TARGET" = "arm" ]; then
         # For arm
-        ./configure CPPFLAGS="-I${OPENSSL_BUILD_DIR}/include" LDFLAGS="-L${OPENSSL_BUILD_DIR}/lib" --prefix=${CURL_BUILD_DIR} --host=arm --with-ssl=${OPENSSL_BUILD_DIR} --with-pic --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl --without-zlib
+        ./configure CPPFLAGS="-I${OPENSSL_BUILD_DIR}/include" LDFLAGS="-L${OPENSSL_BUILD_DIR}/lib" --prefix=${CURL_BUILD_DIR} --host=arm-none-linux-gnu --with-ssl=${OPENSSL_BUILD_DIR} --enable-shared --enable-static --with-pic --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl --without-zlib
     else
         # For linux
         if [ "$OPENSSL_IS_SYSTEM_INSTALLED" -eq 1 ]; then
-            ./configure --prefix=${CURL_BUILD_DIR} --with-ssl --without-zlib --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl
+            ./configure --prefix=${CURL_BUILD_DIR} --with-ssl --without-zlib --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl  --enable-shared --enable-static
         else
-            ./configure CPPFLAGS="-I${OPENSSL_BUILD_DIR}/include" LDFLAGS="-L${OPENSSL_BUILD_DIR}/lib" --prefix=${CURL_BUILD_DIR} --with-ssl=${OPENSSL_BUILD_DIR} --with-pic --without-zlib --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl
+            ./configure CPPFLAGS="-I${OPENSSL_BUILD_DIR}/include" LDFLAGS="-L${OPENSSL_BUILD_DIR}/lib" --prefix=${CURL_BUILD_DIR} --with-ssl=${OPENSSL_BUILD_DIR} --with-pic --without-zlib --without-libpsl --without-libidn2 --disable-docs --disable-libcurl-option --disable-alt-svc --disable-headers-api --disable-hsts --without-libgsasl --enable-shared --enable-static
         fi
     fi
     make $@; make $@ install

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -84,19 +84,26 @@ int init_curl_symbols()
 {
     UT_LOG_DEBUG("Initializing curl symbols from %s", LIBCURL_PATH);
     curl_lib = dlopen(LIBCURL_PATH, RTLD_LAZY);
+    assert(curl_lib != NULL);
     if (curl_lib == NULL)
     {
-        UT_LOG_ERROR("dlopen failed: %s\n", dlerror());
+        UT_LOG_ERROR("dlopen failed for library %s: %s\n", LIBCURL_PATH, dlerror());
         return -1;
     }
 
     // Load the curl function symbols
     kvp_curl_easy_init = (curl_easy_init_t)dlsym(curl_lib, "curl_easy_init");
+    assert(kvp_curl_easy_init != NULL);
     kvp_curl_easy_setopt = (curl_easy_setopt_t)dlsym(curl_lib, "curl_easy_setopt");
+    assert(kvp_curl_easy_setopt != NULL);
     kvp_curl_easy_perform = (curl_easy_perform_t)dlsym(curl_lib, "curl_easy_perform");
+    assert(kvp_curl_easy_perform != NULL);
     kvp_curl_easy_getinfo = (curl_easy_getinfo_t)dlsym(curl_lib, "curl_easy_getinfo");
+    assert(kvp_curl_easy_getinfo != NULL);
     kvp_curl_easy_cleanup = (curl_easy_cleanup_t)dlsym(curl_lib, "curl_easy_cleanup");
+    assert(kvp_curl_easy_cleanup != NULL);
     kvp_curl_easy_strerror = (curl_easy_strerror_t)dlsym(curl_lib, "curl_easy_strerror");
+    assert(kvp_curl_easy_strerror != NULL);
 
     if ((kvp_curl_easy_init == NULL) || (kvp_curl_easy_setopt == NULL) || (kvp_curl_easy_perform == NULL) ||
         (kvp_curl_easy_getinfo == NULL) || (kvp_curl_easy_cleanup ==NULL) || (kvp_curl_easy_strerror == NULL))
@@ -1006,7 +1013,7 @@ static struct fy_node* process_include(const char *filename, int depth, struct f
 
    if (strncmp(filename, "http:", 5) == 0 || strncmp(filename, "https:", 6) == 0) 
    {
-        // URL include
+        // init curl symbols if not already initialized
         if (curl_lib == NULL && init_curl_symbols() != 0)
         {
             UT_LOG_ERROR("Error: Could not initialize curl symbols\n");

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -82,12 +82,12 @@ static void *curl_lib = NULL;
 
 int init_curl_symbols()
 {
-    UT_LOG_DEBUG("Initializing curl symbols from %s", LIBCURL_PATH);
-    curl_lib = dlopen(LIBCURL_PATH, RTLD_LAZY);
+    UT_LOG_DEBUG("Initializing curl symbols from %s", "libcurl.so.4");
+    curl_lib = dlopen("libcurl.so.4", RTLD_LAZY);
     assert(curl_lib != NULL);
     if (curl_lib == NULL)
     {
-        UT_LOG_ERROR("dlopen failed for library %s: %s\n", LIBCURL_PATH, dlerror());
+        UT_LOG_ERROR("dlopen failed for curl library %s: %s with major version 4\n", "libcurl.so.4", dlerror());
         return -1;
     }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,12 @@ build:
 	$(ROOT_DIR)/build.sh
 	make -C ./ut-core test
 	@cp $(LIB_DIR)/lib* ${BIN_DIR}
+	@if [ -d $(LIB_DIR)/../curl ]; then \
+		cp $(LIB_DIR)/../curl/lib/lib*.so* ${BIN_DIR}; \
+	fi
+	@if [ -d $(LIB_DIR)/../openssl ]; then \
+		cp $(LIB_DIR)/../openssl/lib/lib*.so* ${BIN_DIR}; \
+	fi
 	@cp ${ROOT_DIR}/src/*.sh ${BIN_DIR}
 	@cp ${ROOT_DIR}/websocket-clients/* ${BIN_DIR}
 	@$(ECHOE) ${GREEN}Copy Assets to [${BIN_DIR}/assets] ${NC}

--- a/tests/src/ut_control_test.sh
+++ b/tests/src/ut_control_test.sh
@@ -25,6 +25,6 @@ MY_DIR="$(dirname $SCRIPT_EXEC)"
 
 cd "$(dirname "$0")"
 
-export LD_LIBRARY_PATH=/usr/lib:/lib:/home/root:${MY_DIR}
+export LD_LIBRARY_PATH=/usr/lib:/lib:/home/root:${MY_DIR}:${MY_DIR}/lib
 
 ./ut_control_test $@


### PR DESCRIPTION
Modify ut_kvp.c file to load curl library at runtime. This reduces the size of libut_control.so to upto 4.8M from 15M.
Also, didn't notice any change in functionality.