### PR TITLE
PR #81 : Add support for resolving anchors, aliases and mergekeys in yaml

### DIFF
--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -133,6 +133,13 @@ ut_kvp_status_t ut_kvp_open(ut_kvp_instance_t *pInstance, char *fileName)
         return UT_KVP_STATUS_PARSING_ERROR;
     }
 
+    if(fy_document_resolve(pInternal->fy_handle) != 0)
+    {
+        UT_LOG_ERROR("Error resolving document for anchors, aliases and merge keys");
+        ut_kvp_close(pInstance);
+        return UT_KVP_STATUS_PARSING_ERROR;
+    }
+
     node = process_node(fy_document_root(pInternal->fy_handle), 0);
     remove_include_keys(node);
 
@@ -175,6 +182,13 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
     {
         UT_LOG_ERROR("Unable to parse file/memory");
         ut_kvp_close( pInstance );
+        return UT_KVP_STATUS_PARSING_ERROR;
+    }
+
+    if(fy_document_resolve(pInternal->fy_handle) != 0)
+    {
+        UT_LOG_ERROR("Error resolving document for anchors, aliases and merge keys");
+        ut_kvp_close(pInstance);
         return UT_KVP_STATUS_PARSING_ERROR;
     }
 

--- a/tests/src/assets/anchor_aliases_mergekey.yaml
+++ b/tests/src/assets/anchor_aliases_mergekey.yaml
@@ -1,0 +1,9 @@
+# Define a base configuration with an anchor
+base: &base
+  host: localhost
+  port: 80
+
+# Use merge key to include base
+server:
+  <<: *base
+  protocol: http

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -38,6 +38,7 @@
 #define KVP_VALID_TEST_SINGLE_INCLUDE_URL_YAML "assets/include/single-include-url.yaml"
 #define KVP_VALID_TEST_DEPTH_CHECK_INCLUDE_YAML "assets/include/depth_check.yaml"
 #define KVP_VALID_TEST_YAML_CONFIG_FILE "assets/config-test.yaml"
+#define KVP_VALID_TEST_RESOLVE_ALIASES_ANCHORS_MERGEKEYS_YAML "assets/anchor_aliases_mergekey.yaml"
 
 static ut_kvp_instance_t *gpMainTestInstance = NULL;
 static UT_test_suite_t *gpKVPSuite = NULL;
@@ -874,6 +875,13 @@ void test_ut_kvp_IncludeDepthCheckWithBuildFromFile(void)
     create_delete_kvp_instance_for_given_file(KVP_VALID_TEST_DEPTH_CHECK_INCLUDE_YAML);
 }
 
+/* these tests, resolve aliases, anchors and merge keys in given file */
+void test_ut_kvp_ResolveAliasesAnchorsMergeKeysWithBuildFromFile(void)
+{
+
+    create_delete_kvp_instance_for_given_file(KVP_VALID_TEST_RESOLVE_ALIASES_ANCHORS_MERGEKEYS_YAML);
+}
+
 static void create_delete_kvp_memory_instance_for_given_file(const char* filename)
 {
     test_ut_memory_t kvpMemory;
@@ -942,6 +950,13 @@ void test_ut_kvp_IncludeDepthCheckWithBuildFromMallocedData(void)
 {
 
     create_delete_kvp_memory_instance_for_given_file(KVP_VALID_TEST_DEPTH_CHECK_INCLUDE_YAML);
+}
+
+/* these tests, resolve aliases, anchors and merge keys in malloc'd data */
+void test_ut_kvp_ResolveAliasesAnchorsMergeKeysWithBuildFromMallocedData(void)
+{
+
+    create_delete_kvp_memory_instance_for_given_file(KVP_VALID_TEST_RESOLVE_ALIASES_ANCHORS_MERGEKEYS_YAML);
 }
 
 static int test_ut_kvp_createGlobalYAMLInstance( void )
@@ -1213,6 +1228,7 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite8, "kvp single include file", test_ut_kvp_open_singleIncludeFileWithBuildFromFile);
     UT_add_test(gpKVPSuite8, "kvp single include url", test_ut_kvp_singleIncludeUrlsWithBuildFromFile);
     UT_add_test(gpKVPSuite8, "kvp include depth check", test_ut_kvp_IncludeDepthCheckWithBuildFromFile);
+    UT_add_test(gpKVPSuite8, "kvp resolve aliases, anchors, mergekeys", test_ut_kvp_ResolveAliasesAnchorsMergeKeysWithBuildFromFile);
 
     gpKVPSuite9 = UT_add_suite("ut-kvp - test main functions YAML Decoder for single include files using build from Malloced data", NULL, NULL);
     assert(gpKVPSuite9 != NULL);
@@ -1220,6 +1236,7 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite9, "kvp single include file", test_ut_kvp_singleIncludeFileWithBuildFromMallocedData);
     UT_add_test(gpKVPSuite9, "kvp single include url", test_ut_kvp_singleIncludeUrlsWithBuildFromMallocedData);
     UT_add_test(gpKVPSuite9, "kvp include depth check", test_ut_kvp_IncludeDepthCheckWithBuildFromMallocedData);
+    UT_add_test(gpKVPSuite9, "kvp resolve aliases, anchors, mergekeys", test_ut_kvp_ResolveAliasesAnchorsMergeKeysWithBuildFromMallocedData);
 
     gpKVPSuite10 = UT_add_suite("ut-kvp - test main functions YAML Decoder for Yaml include support", test_ut_kvp_createGlobalYAMLInstanceForIncludeFileViaYaml, test_ut_kvp_freeGlobalInstance);
     assert(gpKVPSuite10 != NULL);


### PR DESCRIPTION
This pull request integrates ut-controls functionality to enable support for YAML anchors, aliases, and merge keys.

input yaml:
```
# Define a base configuration with an anchor
base: &base
  host: localhost
  port: 80

# Use merge key to include base
server:
  <<: *base
  protocol: http
``` 

output yaml:
```
base:
  host: localhost
  port: 80
server:
  port: 80
  host: localhost
  protocol: http
``` 