### PR TITLE
Missing Include Guards in ut_control_plane.h Causes Compilation Error

### DIFF
--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -1,4 +1,5 @@
 /*
+ *
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
@@ -17,11 +18,10 @@
  * limitations under the License.
  */
 
-
-#include <ut_kvp.h>
-
 #ifndef UT_CONTROL_PLANE_H
 #define UT_CONTROL_PLANE_H
+
+#include <ut_kvp.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -125,3 +125,5 @@ char *UT_Control_GetMapString(const ut_control_keyStringMapping_t *conversionMap
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* UT_CONTROL_PLANE_H */

--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -20,6 +20,9 @@
 
 #include <ut_kvp.h>
 
+#ifndef UT_CONTROL_PLANE_H
+#define UT_CONTROL_PLANE_H
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
The ut_control_plane.h header file lacks include guards (#ifndef/#define/#endif) or #pragma once, leading to a compilation error due to multiple definitions of the ut_control_keyStringMapping_t typedef when the header is included multiple times in a compilation unit. This causes a "conflicting declaration" error during compilation.

So, added include guards for header file.