### PR TITLE
PR : gh #96:Improved documentation for control plane apis

### DIFF
--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -51,6 +51,7 @@ typedef struct
 typedef void ut_controlPlane_instance_t; /*!< Handle to a control plane instance */
 
 /** @brief  Callback function type for handling control plane messages. */
+/*Responsibility: The callback/client is responsible for freeing the instance */
 typedef void (*ut_control_callback_t)( char *key, ut_kvp_instance_t *instance, void *userData );
 
 /**

--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -50,8 +50,30 @@ typedef struct
 
 typedef void ut_controlPlane_instance_t; /*!< Handle to a control plane instance */
 
-/** @brief  Callback function type for handling control plane messages. */
-/*Responsibility: The callback/client is responsible for freeing the instance */
+/**
+ * @typedef ut_control_callback_t
+ * @brief Function pointer type for control plane message callbacks.
+ *
+ * The callback is invoked synchronously when a registered message key is
+ * received. Its primary purpose is to notify the caller that the key has been
+ * triggered. The accompanying data is provided for informational use and
+ * transient decision-making within the callback.
+ *
+ * The data associated with the `instance` parameter is only valid for the
+ * duration of the callback execution. In most cases, it is not expected to be
+ * copied, as it is intended for on-the-spot processing. However, if the caller
+ * requires the data for further use outside the callback, they may copy it
+ * into their own storage before returning.
+ *
+ * Memory management of the `instance` is handled internally. The caller must
+ * not free it, and must not use it after the callback has returned.
+ *
+ * @param key - Null-terminated string representing the message key that
+ *              triggered the callback.
+ * @param instance - Pointer to a key-value pair (`ut_kvp_instance_t`) instance
+ *                   containing the message data. Valid only during the callback.
+ * @param userData - User-provided pointer passed during callback registration.
+ */
 typedef void (*ut_control_callback_t)( char *key, ut_kvp_instance_t *instance, void *userData );
 
 /**
@@ -62,17 +84,29 @@ typedef void (*ut_control_callback_t)( char *key, ut_kvp_instance_t *instance, v
 ut_controlPlane_instance_t* UT_ControlPlane_Init( uint32_t monitorPort );
 
 /**
- * @brief Registers a callback function for a specific message key.
- * @param pInstance - Handle to the control plane instance.
- * @param key - Null-terminated string representing the message key to trigger the callback.
- * @param callbackFunction - Callback function to be invoked when the key is received.
- * @param userData - Handle to the caller instance.
- * @returns Status of the registration operation (`ut_control_plane_status_t`).
- * @retval UT_CONTROL_PLANE_STATUS_OK - Success
- * @retval UT_CONTROL_PLANE_STATUS_INVALID_HANDLE  - Invalid control plane instance handle.
- * @retval UT_CONTROL_PLANE_STATUS_INVALID_PARAM - Invalid parameter passed
- * @retval UT_CONTROL_PLANE_STATUS_CALLBACK_LIST_FULL  - Callback list is full
- */
+* @brief Registers a synchronous callback function for a specific message key.
+*
+* The callback is invoked immediately when the specified key is received.
+* The data provided to the callback is only valid for the duration of the
+* callback execution. If the user wishes to retain or process the data
+* after the callback returns, they must copy it to their own storage.
+*
+* The memory associated with the callback data is automatically released
+* once the callback returns. It is NOT the responsibility of the caller
+* to free this memory. However, it is the responsibility of the caller
+* to ensure they do not access or use the callback data after the
+* callback has returned.
+*
+* @param pInstance - Handle to the control plane instance.
+* @param key - Null-terminated string representing the message key to trigger the callback.
+* @param callbackFunction - Callback function to be invoked synchronously when the key is received.
+* @param userData - User-provided handle passed back to the callback.
+* @returns Status of the registration operation (`ut_control_plane_status_t`).
+* @retval UT_CONTROL_PLANE_STATUS_OK - Success.
+* @retval UT_CONTROL_PLANE_STATUS_INVALID_HANDLE - Invalid control plane instance handle.
+* @retval UT_CONTROL_PLANE_STATUS_INVALID_PARAM - Invalid parameter passed.
+* @retval UT_CONTROL_PLANE_STATUS_CALLBACK_LIST_FULL - Callback list is full.
+*/
 ut_control_plane_status_t UT_ControlPlane_RegisterCallbackOnMessage(ut_controlPlane_instance_t *pInstance,
                                                                     char *key,
                                                                     ut_control_callback_t callbackFunction,

--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -52,32 +52,31 @@ typedef void ut_controlPlane_instance_t; /*!< Handle to a control plane instance
 
 /**
  * @typedef ut_control_callback_t
- * @brief Function pointer type for control plane message callbacks.
+ * @brief Synchronous control-plane message callback.
  *
- * The callback is invoked synchronously when a registered message key is
- * received. Its primary purpose is to notify the caller that the key has been
- * triggered. The accompanying data is provided for informational use and
- * transient decision-making within the callback.
+ * This callback is invoked when a registered message key is received.
+ * The call is synchronous; return promptly.
  *
- * The data associated with the `instance` parameter is only valid for the
- * duration of the callback execution. In most cases, it is not expected to be
- * copied, as it is intended for on-the-spot processing. However, if the caller
- * requires the data for further use outside the callback, they may copy it
- * into their own storage before returning.
+ * ## Lifetime & ownership
+ * - `instance` is a framework-owned handle valid **only for the duration of
+ *   this callback**. Do not store it or any pointers into its internals.
+ * - To retain payload beyond the callback, extract a serialized copy with
+ *   `ut_kvp_getData()`, copy that data into your own storage/IPC buffer, and
+ *   then `free()` the buffer returned by `ut_kvp_getData()` **before returning**.
+ * - Parsing (e.g., `ut_kvp_openMemory()`) should be done later, outside the
+ *   callback, using the copy you made.
  *
- * ut_kvp.h provides functions to extract data block from the `instance`.
- * Ex: ut_kvp_getData()
+ * ## Typical workflow
+ * - In-callback: fast decisions via typed getters; or stage the message by
+ *   copying the serialized blob to a queue/shared memory for deferred work.
+ * - Out-of-callback: reconstruct a KVP instance from the staged bytes with
+ *   `ut_kvp_openMemory()`.
  *
- * Memory management of the `instance` is handled internally. The caller must
- * not free it, and must not use it after the callback has returned.
- *
- * @param key - Null-terminated string representing the message key that
- *              triggered the callback.
- * @param instance - Pointer to a key-value pair (`ut_kvp_instance_t`) instance
- *                   containing the message data. Valid only during the callback.
- * @param userData - User-provided pointer passed during callback registration.
+ * @param key       Null-terminated message key that triggered the callback.
+ * @param instance  Transient KVP handle containing message data.
+ * @param userData  User pointer provided at registration.
  */
-typedef void (*ut_control_callback_t)( char *key, ut_kvp_instance_t *instance, void *userData );
+typedef void (*ut_control_callback_t)(char *key, ut_kvp_instance_t *instance, void *userData);
 
 /**
  * @brief Initializes a control plane instance.
@@ -90,15 +89,18 @@ ut_controlPlane_instance_t* UT_ControlPlane_Init( uint32_t monitorPort );
 * @brief Registers a synchronous callback function for a specific message key.
 *
 * The callback is invoked immediately when the specified key is received.
-* The data provided to the callback is only valid for the duration of the
-* callback execution. If the user wishes to retain or process the data
-* after the callback returns, they must copy it to their own storage.
 *
-* The memory associated with the callback data is automatically released
-* once the callback returns. It is NOT the responsibility of the caller
-* to free this memory. However, it is the responsibility of the caller
-* to ensure they do not access or use the callback data after the
-* callback has returned.
+* ## Data lifetime of callback parameters
+* - The `instance` parameter provided to the callback is framework-owned and
+*   valid only for the duration of the callback execution.
+* - Do not attempt to free or retain `instance` directly. It is released
+*   automatically after the callback returns.
+* - If the application needs to retain message contents beyond the callback,
+*   it must make a copy. The common pattern is:
+*   - Use `ut_kvp_getData(instance)` to obtain a serialized payload (caller-owned).
+*   - Copy that payload into application-owned memory (e.g. queue, IPC buffer).
+*   - Free the buffer returned by `ut_kvp_getData()` before returning.
+*   - Later, reconstruct a KVP instance with `ut_kvp_openMemory()`.
 *
 * @param pInstance - Handle to the control plane instance.
 * @param key - Null-terminated string representing the message key to trigger the callback.

--- a/include/ut_control_plane.h
+++ b/include/ut_control_plane.h
@@ -65,6 +65,9 @@ typedef void ut_controlPlane_instance_t; /*!< Handle to a control plane instance
  * requires the data for further use outside the callback, they may copy it
  * into their own storage before returning.
  *
+ * ut_kvp.h provides functions to extract data block from the `instance`.
+ * Ex: ut_kvp_getData()
+ *
  * Memory management of the `instance` is handled internally. The caller must
  * not free it, and must not use it after the callback has returned.
  *

--- a/include/ut_kvp.h
+++ b/include/ut_kvp.h
@@ -82,21 +82,21 @@ void ut_kvp_destroyInstance(ut_kvp_instance_t *pInstance);
  */
 ut_kvp_status_t ut_kvp_open(ut_kvp_instance_t *pInstance, char *fileName);
 
-/**!
- * @brief Opens and parses a memory block read from a Key-Value Pair (KVP) file into a KVP instance.
+/**
+ * @brief Parses a KVP payload from a caller-owned memory block into an instance.
  *
- * This function opens the specified memory block, reads its contents, and parses the key-value
- * pairs into the given KVP instance.The memory passed gets freed as part of destroy instance
+ * `pData` must point to a buffer owned by the caller (e.g., allocated with malloc).
+ * This function does not take ownership of `pData`. The caller is always
+ * responsible for freeing `pData`, regardless of success or failure.
  *
- * @param[in] pInstance - Handle to the KVP instance where the parsed data will be stored.
- * @param[in] pData - points to malloc'd memory containing KVP Data.
- * @param[in] length - size of the KVP data
+ * @param[in] pInstance  Destination KVP instance (created with `ut_kvp_createInstance()`).
+ * @param[in] pData      Caller-owned buffer containing the serialized KVP payload (text).
+ * @param[in] length     Size of `pData` in bytes (use `strlen(pData)+1` for text).
  *
- * @returns Status of the operation (`ut_kvp_status_t`):
- * @retval UT_KVP_STATUS_SUCCESS - The file was opened and parsed successfully.
- * @retval UT_KVP_STATUS_INVALID_PARAM - One or more parameters are invalid (e.g., null pointer).
- * @retval UT_KVP_STATUS_PARSING_ERROR - An error occurred while parsing the file contents.
- * @retval UT_KVP_STATUS_INVALID_INSTANCE - The provided `pInstance` is not a valid KVP instance.
+ * @retval UT_KVP_STATUS_SUCCESS            Parsed successfully.
+ * @retval UT_KVP_STATUS_INVALID_PARAM      Invalid pointer/length.
+ * @retval UT_KVP_STATUS_PARSING_ERROR      Malformed payload.
+ * @retval UT_KVP_STATUS_INVALID_INSTANCE   Invalid destination instance.
  */
 ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uint32_t length);
 
@@ -212,13 +212,19 @@ double ut_kvp_getDoubleField( ut_kvp_instance_t *pInstance, const char *pszKey);
 bool ut_kvp_fieldPresent( ut_kvp_instance_t *pInstance, const char *pszKey);
 
 /**
- * @brief Get the data block from the instance, user to free the instance
+ * @brief Returns a heap-allocated textual serialization of a KVP instance.
  *
- * Where the data is invalid, no output will occur
- * Also caller needs to ensure, that they
- * free the pointer to the data block
+ * The buffer is a NUL-terminated string representing the complete payload
+ * of `pInstance`. The caller owns the buffer and must `free()` it when done.
  *
- * @param pInstance - pointer to the KVP instance
+ * If used in callbacks: obtain the blob, copy it into your own
+ * queue/IPC storage, then `free()` the original blob before returning.
+ *
+ * The returned data can later be parsed with `ut_kvp_openMemory()`.
+ * Returns NULL on error or if no data is available.
+ *
+ * @param[in]  pInstance  KVP instance handle to serialize.
+ * @return char*          Malloc'd NUL-terminated string, or NULL on error.
  */
 char* ut_kvp_getData( ut_kvp_instance_t *pInstance );
 

--- a/src/ut_control_plane.c
+++ b/src/ut_control_plane.c
@@ -167,8 +167,8 @@ static void call_callback_on_match(cp_message_t *mssg, ut_cp_instance_internal_t
             // call callback
             entry.pCallback(entry.key, pkvpInstance, entry.userData);
         }
-        ut_kvp_destroyInstance(pkvpInstance);
     }
+    ut_kvp_destroyInstance(pkvpInstance);
     return;
 }
 

--- a/src/ut_control_plane.c
+++ b/src/ut_control_plane.c
@@ -166,9 +166,8 @@ static void call_callback_on_match(cp_message_t *mssg, ut_cp_instance_internal_t
         {
             // call callback
             entry.pCallback(entry.key, pkvpInstance, entry.userData);
-            // pKvpInstance should not be used after this point as it is destroyed in the callback
-            // responsibility of the callback/client to destroy the instance
         }
+        ut_kvp_destroyInstance(pkvpInstance);
     }
     return;
 }

--- a/src/ut_control_plane.c
+++ b/src/ut_control_plane.c
@@ -387,7 +387,14 @@ static struct lws_protocols protocols[] = {
 ut_controlPlane_instance_t *UT_ControlPlane_Init( uint32_t monitorPort )
 {
     ut_cp_instance_internal_t *pInstance;
-  
+
+    if ( monitorPort == 0 )
+    {
+        //assert( pInstance != NULL );
+        UT_CONTROL_PLANE_ERROR("port cannot be 0\n");
+        return NULL;
+    }
+
     pInstance = malloc(sizeof(ut_cp_instance_internal_t));
     memset(pInstance, 0, sizeof(ut_cp_instance_internal_t));
 
@@ -395,13 +402,6 @@ ut_controlPlane_instance_t *UT_ControlPlane_Init( uint32_t monitorPort )
     {
         //assert( pInstance != NULL );
         UT_CONTROL_PLANE_ERROR("Malloc was not able to provide memory\n");
-        return NULL;
-    }
-
-    if ( monitorPort == 0 )
-    {
-        //assert( pInstance != NULL );
-        UT_CONTROL_PLANE_ERROR("port cannot be 0\n");
         return NULL;
     }
 

--- a/src/ut_control_plane.c
+++ b/src/ut_control_plane.c
@@ -166,9 +166,10 @@ static void call_callback_on_match(cp_message_t *mssg, ut_cp_instance_internal_t
         {
             // call callback
             entry.pCallback(entry.key, pkvpInstance, entry.userData);
+            // pKvpInstance should not be used after this point as it is destroyed in the callback
+            // responsibility of the callback/client to destroy the instance
         }
     }
-    ut_kvp_destroyInstance(pkvpInstance);
     return;
 }
 

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -98,13 +98,12 @@ void ut_kvp_destroyInstance(ut_kvp_instance_t *pInstance)
 ut_kvp_status_t ut_kvp_open(ut_kvp_instance_t *pInstance, char *fileName)
 {
     struct fy_node *node;
-    ut_kvp_instance_internal_t *pInternal = validateInstance(pInstance);
-
     if (pInstance == NULL)
     {
         return UT_KVP_STATUS_INVALID_INSTANCE;
     }
 
+    ut_kvp_instance_internal_t *pInternal = validateInstance(pInstance);
     if (fileName == NULL)
     {
         UT_LOG_ERROR( "Invalid Param [fileName]" );
@@ -1027,6 +1026,7 @@ static void merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
     if (fy_node_is_scalar(mainNode))
     {
         fy_node_create_scalar_copy(fy_node_document(mainNode), fy_node_get_scalar(includeNode, NULL), fy_node_get_scalar_length(includeNode));
+        free((void *)fy_node_get_scalar(includeNode, NULL));
     }
     else if (fy_node_is_mapping(mainNode) && fy_node_is_mapping(includeNode))
     {

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -161,6 +161,7 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
 {
     struct fy_node *node;
     ut_kvp_instance_internal_t *pInternal = validateInstance(pInstance);
+    char *cData = NULL;
 
     if (pInstance == NULL)
     {
@@ -173,9 +174,11 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
         return UT_KVP_STATUS_INVALID_PARAM;
     }
 
+    cData = strdup((const char*)pData);
+
     if (pInternal->fy_handle)
     {
-        merge_nodes(fy_document_root(pInternal->fy_handle), fy_document_root(fy_document_build_from_malloc_string(NULL, pData, length)));
+        merge_nodes(fy_document_root(pInternal->fy_handle), fy_document_root(fy_document_build_from_malloc_string(NULL, cData, length)));
     }
     else
     {
@@ -189,7 +192,7 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
         return UT_KVP_STATUS_PARSING_ERROR;
     }
 
-    struct fy_document *srcDoc = fy_document_build_from_malloc_string(NULL, pData, length);
+    struct fy_document *srcDoc = fy_document_build_from_malloc_string(NULL, cData, length);
 
     if(fy_document_resolve(srcDoc) != 0)
     {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -40,6 +40,9 @@ BUILD_DIR = $(ROOT_DIR)/build/$(TARGET)/obj
 ifeq ($(TARGET),)
 $(info TARGET FORCED TO Linux)
 TARGET=linux
+CFLAGS   += -g -O1 -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak
+CXXFLAGS += $CFLAGS
+YLDFLAGS  += -fsanitize=address -fsanitize=leak
 endif
 
 $(info TARGET [$(TARGET)])

--- a/tests/src/ut_test_control_plane.c
+++ b/tests/src/ut_test_control_plane.c
@@ -190,7 +190,6 @@ void testYAMLCallback(char *key, ut_kvp_instance_t *instance, void* userData)
 
     //UT_ASSERT_STRING_EQUAL(kvpData, data);
     gMessageRecievedYAML = true;
-    ut_kvp_destroyInstance(instance); // free the instance here as it is created in the control plane
 }
 
 void testJSONCallback(char *key, ut_kvp_instance_t *instance, void* userData)
@@ -216,7 +215,6 @@ void testJSONCallback(char *key, ut_kvp_instance_t *instance, void* userData)
 
     //UT_ASSERT_STRING_EQUAL(kvpData, data);
     gMessageRecievedJSON = true;
-    ut_kvp_destroyInstance(instance); // free the instance here as it is created in the control plane
 }
 
 static void UT_ControlPlane_Sigint_Handler(int sig)

--- a/tests/src/ut_test_control_plane.c
+++ b/tests/src/ut_test_control_plane.c
@@ -190,6 +190,7 @@ void testYAMLCallback(char *key, ut_kvp_instance_t *instance, void* userData)
 
     //UT_ASSERT_STRING_EQUAL(kvpData, data);
     gMessageRecievedYAML = true;
+    ut_kvp_destroyInstance(instance); // free the instance here as it is created in the control plane
 }
 
 void testJSONCallback(char *key, ut_kvp_instance_t *instance, void* userData)
@@ -215,6 +216,7 @@ void testJSONCallback(char *key, ut_kvp_instance_t *instance, void* userData)
 
     //UT_ASSERT_STRING_EQUAL(kvpData, data);
     gMessageRecievedJSON = true;
+    ut_kvp_destroyInstance(instance); // free the instance here as it is created in the control plane
 }
 
 static void UT_ControlPlane_Sigint_Handler(int sig)

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -424,7 +424,6 @@ void test_ut_kvp_dataByte( void )
 {
     int bytes_count = 0;
     unsigned char *output_bytes;
-    test_ut_memory_t kvpdata;
 
     /* Check for NULL_PARAM */
     UT_LOG_STEP("ut_kvp_getDataBytes() - Check for NULL_PARAM - First Argument");
@@ -449,10 +448,6 @@ void test_ut_kvp_dataByte( void )
     UT_ASSERT(bytes_count == 0);
 
     /* Positive tests */
-     if (read_file_into_memory(KVP_VALID_TEST_YAML_FILE, &kvpdata) == 0)
-    {
-        printf("\nYAML file is = \n%s\n", kvpdata.buffer);
-    }
     UT_LOG_STEP("ut_kvp_getDataBytes() - checkBytesSpace for valid output_bytes and bytes_count");
     output_bytes = ut_kvp_getDataBytes(gpMainTestInstance, "decodeTest/checkBytesSpace", &bytes_count);
     UT_ASSERT(output_bytes != NULL);
@@ -978,7 +973,7 @@ static void create_delete_kvp_memory_instance_for_given_file(const char* filenam
 {
     test_ut_memory_t kvpMemory;
     ut_kvp_instance_t *pInstance = NULL;
-    ut_kvp_status_t status;
+    ut_kvp_status_t status = UT_KVP_STATUS_MAX;
     char* kvpData;
 
     pInstance = ut_kvp_createInstance();
@@ -1122,7 +1117,7 @@ static int test_ut_kvp_createGlobalJSONInstance( void )
 
 static int test_ut_kvp_createGlobalYAMLInstanceForMallocedData( void )
 {
-    ut_kvp_status_t status;
+    ut_kvp_status_t status = UT_KVP_STATUS_MAX;
     test_ut_memory_t kvpMemory;
 
     gpMainTestInstance = ut_kvp_createInstance();
@@ -1152,7 +1147,7 @@ static int test_ut_kvp_createGlobalYAMLInstanceForMallocedData( void )
 
 static int test_ut_kvp_createGlobalJSONInstanceForMallocedData( void )
 {
-    ut_kvp_status_t status;
+    ut_kvp_status_t status = UT_KVP_STATUS_MAX;
     test_ut_memory_t kvpMemory;
 
     gpMainTestInstance = ut_kvp_createInstance();

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -174,6 +174,7 @@ void test_ut_kvp_open_memory( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, -1);
         UT_ASSERT(status == UT_KVP_STATUS_PARSING_ERROR);
+        free(gKVPData.buffer);
     }
 
     /* Zero length file, that the library should reject because it can't parse it at all */
@@ -182,6 +183,8 @@ void test_ut_kvp_open_memory( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_PARSING_ERROR);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     /* Positive Tests */
@@ -190,6 +193,8 @@ void test_ut_kvp_open_memory( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     UT_LOG_STEP("ut_kvp_openMemory( gpMainTestInstance, %s ) - Postive", KVP_VALID_TEST_NOT_VALID_YAML_FORMATTED_FILE);
@@ -197,6 +202,8 @@ void test_ut_kvp_open_memory( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     UT_LOG_STEP("ut_kvp_openMemory( gpMainTestInstance, %s ) - Postive", KVP_VALID_TEST_JSON_FILE);
@@ -204,6 +211,8 @@ void test_ut_kvp_open_memory( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 }
 
@@ -845,6 +854,8 @@ void test_ut_kvp_add_multiple_profile_using_open_memory(void)
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     UT_LOG_STEP("ut_kvp_openMemory( gpMainTestInstance, %s ) - Postive", KVP_VALID_TEST_SINGLE_INCLUDE_FILE_YAML);
@@ -852,6 +863,8 @@ void test_ut_kvp_add_multiple_profile_using_open_memory(void)
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     UT_LOG_STEP("ut_kvp_openMemory( gpMainTestInstance, %s ) - Postive", KVP_VALID_TEST_DEPTH_CHECK_INCLUDE_YAML);
@@ -859,6 +872,8 @@ void test_ut_kvp_add_multiple_profile_using_open_memory(void)
     {
         status = ut_kvp_openMemory(gpMainTestInstance, gKVPData.buffer, gKVPData.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(gKVPData.buffer);
+        gKVPData.length = 0;
     }
 
     char* kvpData = ut_kvp_getData(gpMainTestInstance);
@@ -978,6 +993,8 @@ static void create_delete_kvp_memory_instance_for_given_file(const char* filenam
     {
         status = ut_kvp_openMemory(pInstance, kvpMemory.buffer, kvpMemory.length);
         UT_ASSERT(status == UT_KVP_STATUS_SUCCESS);
+        free(kvpMemory.buffer);
+        kvpMemory.length = 0;
     }
 
     if ( status != UT_KVP_STATUS_SUCCESS )
@@ -1120,6 +1137,8 @@ static int test_ut_kvp_createGlobalYAMLInstanceForMallocedData( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, kvpMemory.buffer, kvpMemory.length);
         assert(status == UT_KVP_STATUS_SUCCESS);
+        free(kvpMemory.buffer);
+        kvpMemory.length = 0;
     }
 
     if ( status != UT_KVP_STATUS_SUCCESS )
@@ -1148,6 +1167,8 @@ static int test_ut_kvp_createGlobalJSONInstanceForMallocedData( void )
     {
         status = ut_kvp_openMemory(gpMainTestInstance, kvpMemory.buffer, kvpMemory.length);
         assert(status == UT_KVP_STATUS_SUCCESS);
+        free(kvpMemory.buffer);
+        kvpMemory.length = 0;
     }
 
     if ( status != UT_KVP_STATUS_SUCCESS )


### PR DESCRIPTION
Currently its control plane's responsibility to free the kvp instance after callback is called. 
The client on the other side queues these messages and processes it at its own time. So by the time it processes, the instance is freed.

By transferring the ownership to the client, client can process at its own time and free the instance.


**NOTE** : https://github.com/rdkcentral/ut-control/pull/97#issuecomment-3333532020