### PR TITLE
Feature/gh120 iterate yaml lists

### DIFF
--- a/include/ut_kvp.h
+++ b/include/ut_kvp.h
@@ -48,6 +48,44 @@ typedef enum
 /**! Handle to a KVP instance. */
 typedef void ut_kvp_instance_t;    
 
+/**! Handle to a KVP node iterator */
+typedef void ut_kvp_iterator_t;
+
+/**! Status codes for ut kvp iteration */
+typedef enum
+{
+    /**! The iteration of every element in the sequence was completed successfully */
+    UT_KVP_ITER_STATUS_FINISHED = 0,
+    /**! The given pointer is not a valid ut_kvp_iterator_t */
+    UT_KVP_ITER_STATUS_INVALID_ITERATOR = 1,
+    /**! The given Callback was NULL */
+    UT_KVP_ITER_STATUS_CALLBACK_IS_NULL = 2,
+    /**! The `ut_kvp_iter_result_t` indicated an internal error, such as a failed malloc */
+    UT_KVP_ITER_STATUS_INTERNAL_ERROR = 3,
+    /**! Execution was halted due to a callback returning `false`*/
+    UT_KVP_ITER_STATUS_HALTED = 4,
+} ut_kvp_iter_status_t;
+
+/**! A struct containing the results of iterating using `ut_kvp_iterIterate` */
+typedef struct
+{
+    /**! The number of calls to `ut_kvp_iter_callback_t` during `ut_kvp_iterIterate`*/
+    uint32_t iteration_count;
+    /**! The code determining the exit status of the `ut_kvp_iterIterate` */
+    ut_kvp_iter_status_t status;
+} ut_kvp_iter_result_t;
+
+/**!
+ * @brief Callback function signature for ut kvp iteration
+ *
+ * @param[in] pInstance - The element of the current iteration. The element's data is released after the callback returns;
+ * do not retain the instance or its data beyond this function
+ * @param[in] userData - The userdata relevant to the call
+ *
+ * @returns `true` if iteration should continue `false` if it should halt
+ */
+typedef bool (*ut_kvp_iter_callback_t)(ut_kvp_instance_t *pInstance, void *userData);
+
 #define UT_KVP_MAX_ELEMENT_SIZE (256)  /**!< Maximum size of a single KVP element (in bytes). */
 
 /**!
@@ -106,6 +144,39 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
  * @param[in] pInstance - Handle to the instance to close.
  */
 void ut_kvp_close(ut_kvp_instance_t *pInstance);
+
+/**!
+ * @brief Create an iterator for the given node
+ *
+ * The node given via the `pPath` argument must be of type sequence.
+ * The returned iterator is independent of `pInstance`: once created, the iterator
+ * remains valid even if `pInstance` is closed, destroyed, or further mutated.
+ *
+ * @param[in] pInstance - Root KVP instance containing the node which should be iterated.
+ * @param[in] pPath - The path to the node that should be iterated, relative to the root node of `pInstance`.
+ *
+ * @returns - `ut_kvp_iterator_t *` on success, which must be deallocated using `ut_kvp_iterDestroy`. NULL on failure
+ */
+ut_kvp_iterator_t *ut_kvp_iterCreate(ut_kvp_instance_t *pInstance, const char *pPath);
+
+/**!
+ * @brief Cleans up memory for an iterator
+ *
+ * @param[in] pIterator - `ut_kvp_iterator_t` pointer to deallocate
+ */
+void ut_kvp_iterDestroy(ut_kvp_iterator_t *pIterator);
+
+
+/**!
+ * @brief Performs iteration, executing a callback function for each element.
+ *
+ * @param[in] pIterator - The iterator to iterate
+ * @param[in] callback - The callback function to execute for each element, if it returns `false` iteration stops
+ * @param[in] userData - A pointer to the userdata that will be passed to the callback function on each iteration
+ *
+ * @returns `ut_kvp_iter_result_t` holding a status code and the number of iterations run
+ */
+ut_kvp_iter_result_t ut_kvp_iterIterate(ut_kvp_iterator_t *pIterator, ut_kvp_iter_callback_t callback, void *userData);
 
 /**!
  * @brief Gets a boolean value from the KVP profile.

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -19,11 +19,13 @@
 
 /* Standard Libraries */
 #include <errno.h>
+#include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <unistd.h>
 #include <assert.h>
 #include <curl/curl.h>
+#include <inttypes.h>
 
 /* Application Includes */
 #include <ut_kvp.h>
@@ -35,6 +37,7 @@
 ut_kvp_instance_t *gKVP_Instance = NULL;
 
 #define UT_KVP_MAGIC (0xdeadbeef)
+#define UT_KVP_ITER_MAGIC (0xdecafbad)
 #define UT_KVP_MAX_INCLUDE_DEPTH 5
 
 #define UT_KVP_HTTPS_PREFIX "https://"
@@ -64,8 +67,16 @@ typedef struct
     size_t size;
 } ut_kvp_download_memory_internal_t;
 
+typedef struct
+{
+    uint32_t magic;
+    struct fy_document *document;
+    struct fy_node *iterator_root;
+} ut_kvp_iterator_internal_t;
+
 /* Static functions */
 static ut_kvp_instance_internal_t *validateInstance(ut_kvp_instance_t *pInstance);
+static ut_kvp_iterator_internal_t *validateIterator(ut_kvp_iterator_t *pInstance);
 static unsigned long getUIntField( ut_kvp_instance_t *pInstance, const char *pszKey, unsigned long maxRange );
 static bool str_to_bool(const char *string);
 static ut_kvp_status_t ut_kvp_getField(ut_kvp_instance_t *pInstance, const char *pszKey, char *pszResult);
@@ -348,6 +359,189 @@ void ut_kvp_close(ut_kvp_instance_t *pInstance)
         fy_document_destroy(pInternal->fy_handle);
         pInternal->fy_handle = NULL;
     }
+}
+
+ut_kvp_iterator_t *ut_kvp_iterCreate(ut_kvp_instance_t *pInstance, const char *pPath)
+{
+    ut_kvp_instance_internal_t *pInternal = validateInstance(pInstance);
+    if (pInternal == NULL)
+    {
+        UT_LOG_ERROR("Failed to create iterator, kvp instance was NULL");
+        return NULL;
+    }
+
+    if (pInternal->fy_handle == NULL)
+    {
+        UT_LOG_ERROR("Failed to create iterator, kvp instance not opened");
+        return NULL;
+    }
+
+    if (pPath == NULL)
+    {
+        UT_LOG_ERROR("Failed to create iterator, path was NULL");
+        return NULL;
+    }
+
+    struct fy_document *iterator_doc = fy_document_create(NULL);
+    if (iterator_doc == NULL)
+    {
+        UT_LOG_ERROR("Failed to create a fydoc for the iterator");
+        return NULL;
+    }
+
+    char sanitized_path[UT_KVP_MAX_ELEMENT_SIZE];
+    convert_dot_to_slash(pPath, sanitized_path);
+
+    struct fy_node *sequence_node = fy_node_by_path(
+        fy_document_root(pInternal->fy_handle),
+        sanitized_path,
+        -1, // For null terminated string
+        FYNWF_DONT_FOLLOW
+    );
+
+    if (sequence_node == NULL)
+    {
+        fy_document_destroy(iterator_doc);
+        UT_LOG_ERROR("No node found at: %s", pPath);
+        return NULL;
+    }
+
+    if (!fy_node_is_sequence(sequence_node))
+    {
+        fy_document_destroy(iterator_doc);
+        UT_LOG_ERROR("Iterator node at: %s is not a sequence", pPath);
+        return NULL;
+    }
+    struct fy_node * iterator_root_node = fy_node_copy(iterator_doc, sequence_node);
+
+    if (iterator_root_node == NULL)
+    {
+        fy_document_destroy(iterator_doc);
+        UT_LOG_ERROR("Failed to copy iterator root node at: %s", pPath);
+        return NULL;
+    }
+    
+    const int set_root_result = fy_document_set_root(iterator_doc, iterator_root_node);
+
+    if (set_root_result != 0)
+    {
+        fy_document_destroy(iterator_doc);
+        UT_LOG_ERROR("Failed to set iterator document root");
+        return NULL;
+    }
+    
+    ut_kvp_iterator_internal_t *internal_iter = malloc(sizeof(ut_kvp_iterator_internal_t));
+
+    if (internal_iter == NULL)
+    {
+        fy_document_destroy(iterator_doc);
+        UT_LOG_ERROR("Failed to allocate iterator for path: %s", pPath);
+        return NULL;
+    }
+
+    internal_iter->magic = UT_KVP_ITER_MAGIC;
+    internal_iter->document = iterator_doc;
+    internal_iter->iterator_root = iterator_root_node;
+
+    return (ut_kvp_iterator_t*)internal_iter;
+}
+
+void ut_kvp_iterDestroy(ut_kvp_iterator_t *pIterator)
+{
+    ut_kvp_iterator_internal_t *pInternal = validateIterator(pIterator);
+    if (pInternal == NULL)
+    {
+        UT_LOG_ERROR("pIterator is not a valid ut_kvp_iterator_t pointer");
+        return;
+    }
+
+    // Ensure this no longer holds our magic value
+    pInternal->magic = 0;
+    if (pInternal->document != NULL)
+    {
+        fy_document_destroy(pInternal->document);
+    }
+    free(pInternal);
+}
+
+ut_kvp_iter_result_t ut_kvp_iterIterate(ut_kvp_iterator_t *pIterator, ut_kvp_iter_callback_t callback, void *userData)
+{
+    ut_kvp_iterator_internal_t *fy_iterator = validateIterator(pIterator);
+    ut_kvp_iter_result_t result = { 0, UT_KVP_ITER_STATUS_FINISHED };
+
+    if (fy_iterator == NULL)
+    {
+        UT_LOG_ERROR("pIterator is not a valid ut_kvp_iterator_t pointer");
+        result.status = UT_KVP_ITER_STATUS_INVALID_ITERATOR;
+        return result;
+    }
+
+    if (callback == NULL)
+    {
+        UT_LOG_ERROR("Callback is NULL, no iteration will be done");
+        result.status = UT_KVP_ITER_STATUS_CALLBACK_IS_NULL;
+        return result;
+   }
+
+    struct fy_node *iterated_node;
+    void *prev_iter = NULL;
+    bool callback_result = true;
+    ut_kvp_instance_internal_t *kvp_instance_current_element = ut_kvp_createInstance();
+    if (kvp_instance_current_element == NULL)
+    {
+        UT_LOG_ERROR("Failed to allocate ut_kvp_instance for iterated elements");
+        result.status = UT_KVP_ITER_STATUS_INTERNAL_ERROR;
+        return result;
+    }
+
+    while(
+        (iterated_node = fy_node_sequence_iterate(fy_iterator->iterator_root, &prev_iter)) != NULL &&
+        callback_result
+    )
+    {
+        // In order to set a document root, we must create a new doc, copy the iterated node
+        // and set the copy as root. When we deallocate the document later, the node will go too
+        struct fy_document *fydoc = fy_document_create(NULL);
+        if (fydoc == NULL)
+        {
+            UT_LOG_ERROR("Failed to create new fy_document during iteration %" PRIu32, result.iteration_count + 1);
+            result.status = UT_KVP_ITER_STATUS_INTERNAL_ERROR;
+            break;
+        }
+
+        struct fy_node *node_copy = fy_node_copy(fydoc, iterated_node);
+        if (node_copy == NULL)
+        {
+            fy_document_destroy(fydoc);
+            UT_LOG_ERROR("Failed to copy fy_node during iteration %" PRIu32, result.iteration_count + 1);
+            result.status = UT_KVP_ITER_STATUS_INTERNAL_ERROR;
+            break;
+        }
+
+        if(fy_document_set_root(fydoc, node_copy) != 0)
+        {
+            fy_document_destroy(fydoc);
+            UT_LOG_ERROR("Failed to set document root at iteration: %" PRIu32, result.iteration_count + 1);
+            result.status = UT_KVP_ITER_STATUS_INTERNAL_ERROR;
+            break;
+        }
+
+        kvp_instance_current_element->fy_handle = fydoc;
+
+        callback_result = callback(kvp_instance_current_element, userData);
+        result.iteration_count++;
+
+        // deallocs the document
+        ut_kvp_close(kvp_instance_current_element);
+    }
+    ut_kvp_destroyInstance(kvp_instance_current_element);
+
+    if (!callback_result)
+    {
+        result.status = UT_KVP_ITER_STATUS_HALTED;
+    }
+
+    return result;
 }
 
 char* ut_kvp_getData( ut_kvp_instance_t *pInstance )
@@ -984,6 +1178,25 @@ static ut_kvp_instance_internal_t *validateInstance(ut_kvp_instance_t *pInstance
     if (pInternal->magic != UT_KVP_MAGIC)
     {
         UT_LOG_ERROR("Invalid Handle - magic failure");
+        return NULL;
+    }
+
+    return pInternal;
+}
+
+static ut_kvp_iterator_internal_t *validateIterator(ut_kvp_iterator_t *pIterator)
+{
+    ut_kvp_iterator_internal_t *pInternal = (ut_kvp_iterator_internal_t*)pIterator;
+
+    if (pIterator == NULL)
+    {
+        UT_LOG_ERROR("Invalid Handle");
+        return NULL;
+    }
+
+    if (pInternal->magic != UT_KVP_ITER_MAGIC)
+    {
+        UT_LOG_ERROR("Invalid Handle - Magic Failure");
         return NULL;
     }
 

--- a/tests/src/assets/yaml_simple_and_nested_sequence.yaml
+++ b/tests/src/assets/yaml_simple_and_nested_sequence.yaml
@@ -1,0 +1,27 @@
+decodeTest:
+  checkIterator:
+    - name: 'First Element'
+      id: 0
+    - name: Second Element
+      id: 1
+  checkNestedIteration:
+    - name: 'First Element'
+      id: 0
+      sub_elements:
+        - name: 'First Sub Element'
+          id: 1
+        - name: 'Second Sub Element'
+          id: 2
+    - name: 'Second Element'
+      id: 3
+      sub_elements:
+        - name: 'Third Sub Element'
+          id: 4
+        - name: 'Fourth Sub Element'
+          id: 5
+    - name: 'Third Element'
+      id: 6
+  notASequence:
+    description: |
+      This is really not a sequence
+  emptySequence: []

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -18,14 +18,17 @@
  */
 
 /* Standard Libraries */
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <inttypes.h>
 
 /* Module Includes */
 #include <ut.h>
 #include <ut_kvp.h>
+#include <ut_log.h>
 
 #include "ut_test_common.h"
 
@@ -42,6 +45,7 @@
 #define KVP_VALID_TEST_SEQUENCE_INCLUDE_YAML "assets/include/sequence-include.yaml"
 #define KVP_VALID_TEST_RESOLVE_YAML_TAGS_YAML "assets/yaml_tags.yaml"
 #define KVP_VALID_TEST_RESOLVE_YAML_TAGS_IN_SEQUENCE_YAML "assets/yaml_tags_in_sequence.yaml"
+#define KVP_VALID_TEST_SEQUENCE_ITERATION_YAML "assets/yaml_simple_and_nested_sequence.yaml"
 #define KVP_VALID_TEST_URL_HTTPS "https://raw.githubusercontent.com/rdkcentral/ut-control/main/tests/src/assets/include/2s.yaml"
 #define KVP_VALID_TEST_URI_HTTP "http://localhost:8000/assets/yaml_tags.yaml"
 #define KVP_VALID_TEST_URI_FILE "file://assets/yaml_tags.yaml"
@@ -62,6 +66,7 @@ static UT_test_suite_t *gpKVPSuite9 = NULL;
 static UT_test_suite_t *gpKVPSuite10 = NULL;
 static UT_test_suite_t *gpKVPSuite11 = NULL;
 static UT_test_suite_t *gpKVPSuite12 = NULL;
+static UT_test_suite_t *gpKVPSuite13 = NULL;
 
 static int test_ut_kvp_createGlobalYAMLInstance(void);
 static int test_ut_kvp_createGlobalJSONInstance(void);
@@ -248,6 +253,361 @@ void test_ut_kvp_open_memory( void )
         free(gKVPData.buffer);
         gKVPData.length = 0;
     }
+}
+
+
+void test_ut_kvp_get_iterator_with_two_elements(void)
+{
+
+  char *checkIteratorPath = "decodeTest/checkIterator";
+  ut_kvp_iterator_t *iterator =
+      ut_kvp_iterCreate(gpMainTestInstance, checkIteratorPath);
+
+  UT_ASSERT(iterator != NULL);
+  UT_LOG_STEP("Iterator loaded for path: %s", checkIteratorPath);
+
+  ut_kvp_iterDestroy(iterator);
+  UT_LOG_STEP("Iterator Deallocated");
+}
+
+void test_ut_kvp_get_iterator_with_dotted_path(void)
+{
+
+  char *checkIteratorPath = "decodeTest.checkIterator";
+  ut_kvp_iterator_t *iterator =
+      ut_kvp_iterCreate(gpMainTestInstance, checkIteratorPath);
+
+  UT_ASSERT(iterator != NULL);
+  UT_LOG_STEP("Iterator loaded for path: %s", checkIteratorPath);
+
+  ut_kvp_iterDestroy(iterator);
+  UT_LOG_STEP("Iterator Deallocated");
+}
+
+// A helper type for constructing expectations
+typedef struct iterator_test_data_t
+{
+  const char **names;
+  int32_t *ids;
+  size_t num_elements;
+  int32_t current_idx;
+  struct iterator_test_data_t *sub_elements;
+  int32_t sub_elements_length;
+} iterator_test_data_t;
+
+bool iteration_callback(ut_kvp_instance_t *pInstance, void *userData)
+{
+  iterator_test_data_t *expectations = userData;
+  char name[UT_KVP_MAX_ELEMENT_SIZE + 1] = {0};
+
+  int32_t id = ut_kvp_getInt32Field(pInstance, "id");
+  ut_kvp_status_t name_read_state =
+      ut_kvp_getStringField(pInstance, "name", name, UT_KVP_MAX_ELEMENT_SIZE);
+
+  UT_ASSERT(name_read_state == UT_KVP_STATUS_SUCCESS);
+
+  UT_ASSERT(expectations->current_idx < expectations->num_elements);
+  UT_LOG_STEP("Iteration callback at idx: %d checking that\n  name: %s == %s\n "
+              " id: %d == %d",
+              expectations->current_idx, name,
+              expectations->names[expectations->current_idx], id,
+              expectations->ids[expectations->current_idx]);
+  bool ids_match = id == expectations->ids[expectations->current_idx];
+  bool names_match =
+      strcmp(name, expectations->names[expectations->current_idx]) == 0;
+  // handle sub_elements
+  if (expectations->sub_elements && expectations->sub_elements_length > expectations->current_idx)
+  {
+    UT_LOG_STEP("Handling subiterator at idx: %d", expectations->current_idx);
+    ut_kvp_iterator_t *sub_iterator =
+        ut_kvp_iterCreate(pInstance, "sub_elements");
+    UT_ASSERT(sub_iterator != NULL);
+    if (sub_iterator == NULL)
+    {
+      return false;
+    }
+    const ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(sub_iterator, iteration_callback,
+                        &expectations->sub_elements[expectations->current_idx]);
+    UT_ASSERT(iterResult.iteration_count == expectations->sub_elements[expectations->current_idx].num_elements);
+    ut_kvp_iterDestroy(sub_iterator);
+  }
+
+  UT_ASSERT(ids_match);
+  UT_ASSERT(names_match);
+
+  expectations->current_idx++;
+  return ids_match && names_match;
+}
+
+void test_ut_kvp_iterate_elements(void)
+{
+
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS 2
+
+  const char *names[TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS] = {"First Element", "Second Element"};
+  int32_t ids[TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS] = {0, 1};
+  iterator_test_data_t testData = {
+      .names = names,
+      .ids = ids,
+      .current_idx = 0,
+      .num_elements = TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS,
+      .sub_elements = NULL,
+      .sub_elements_length = 0
+  };
+
+  const char *checkIteratorPath = "decodeTest/checkIterator";
+  ut_kvp_iterator_t *iterator =
+      ut_kvp_iterCreate(gpMainTestInstance, checkIteratorPath);
+
+  ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iterator, iteration_callback, &testData);
+  ut_kvp_iterDestroy(iterator);
+
+  UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_FINISHED);
+  UT_ASSERT(iterResult.iteration_count == TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS);
+}
+
+void test_ut_kvp_iterate_unaffected_by_mutation_of_ut_kvp_instance(void)
+{
+    // SETUP local ut_kvp_instance_t since we do not want to mess with the fixture used for the rest of the tests
+    ut_kvp_status_t status;
+
+    struct ut_kvp_instance_t* localUtKvpInstance = ut_kvp_createInstance();
+    if ( localUtKvpInstance == NULL )
+    {
+        UT_LOG_ERROR("ut_kvp_open() - Read Failure");
+        UT_FAIL("localUtKvpInstance was null");
+        return;
+    }
+
+    status = ut_kvp_open( localUtKvpInstance, KVP_VALID_TEST_SEQUENCE_ITERATION_YAML);
+    assert( status == UT_KVP_STATUS_SUCCESS );
+
+    if ( status != UT_KVP_STATUS_SUCCESS )
+    {
+        UT_LOG_ERROR("ut_kvp_open() - Read Failure");
+        UT_FAIL("localUtKvpInstance status was not UT_KVP_STATUS_SUCCESS");
+        return;
+    }
+
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS_MUT 2
+
+  const char *names[TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS_MUT] = {"First Element", "Second Element"};
+  int32_t ids[TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS_MUT] = {0, 1};
+  iterator_test_data_t testData = {
+      .names = names,
+      .ids = ids,
+      .current_idx = 0,
+      .num_elements = TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS_MUT,
+      .sub_elements = NULL,
+      .sub_elements_length = 0
+  };
+
+  const char *checkIteratorPath = "decodeTest/checkIterator";
+  ut_kvp_iterator_t *iterator =
+      ut_kvp_iterCreate(localUtKvpInstance, checkIteratorPath);
+
+  //Lets close and deallocate the localUtKvpInstance, and check the iterator still works
+  ut_kvp_close(localUtKvpInstance);
+  ut_kvp_destroyInstance(localUtKvpInstance);
+
+  ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iterator, iteration_callback, &testData);
+  ut_kvp_iterDestroy(iterator);
+
+  UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_FINISHED);
+  UT_ASSERT(iterResult.iteration_count == TEST_UT_KVP_ITERATE_ELEMENTS_NUM_ELEMS_MUT);
+}
+
+void test_ut_kvp_iterate_elements_with_sub_elements(void)
+{
+
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_1 2
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_2 2
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_SUB_ELEMS 2
+  #define TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS 3
+
+  const char *sub_names_1[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_1] = {
+      "First Sub Element",
+      "Second Sub Element"
+  };
+  int32_t sub_ids_1[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_1] = {1, 2};
+  iterator_test_data_t sub_elements_1 = {
+      .names = sub_names_1,
+     .ids = sub_ids_1,
+     .num_elements = TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_1,
+     .current_idx = 0,
+     .sub_elements = NULL
+ };
+
+  const char *sub_names_2[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_2] = {
+      "Third Sub Element",
+      "Fourth Sub Element"
+  };
+  int32_t sub_ids_2[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_2] = {4, 5};
+  iterator_test_data_t sub_elements_2 = {
+    .names = sub_names_2,
+    .ids = sub_ids_2,
+    .num_elements = TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS_SUB_2,
+    .current_idx = 0,
+    .sub_elements = NULL
+  };
+  iterator_test_data_t sub_elements[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_SUB_ELEMS] = {
+      sub_elements_1,
+      sub_elements_2
+  };
+
+  const char *names[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS] = {
+      "First Element",
+      "Second Element",
+      "Third Element"
+  };
+  int32_t ids[TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS] = {0, 3, 6};
+  iterator_test_data_t testData = {.names = names,
+                                   .ids = ids,
+                                   .current_idx = 0,
+                                   .num_elements = TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS,
+                                   .sub_elements = sub_elements,
+                                   .sub_elements_length = 2};
+
+  const char *checkIteratorPath = "decodeTest/checkNestedIteration";
+  ut_kvp_iterator_t *iterator =
+      ut_kvp_iterCreate(gpMainTestInstance, checkIteratorPath);
+
+  ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iterator, iteration_callback, &testData);
+  ut_kvp_iterDestroy(iterator);
+
+  UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_FINISHED);
+  UT_ASSERT(iterResult.iteration_count == TEST_UT_KVP_ITERATE_ELEMENTS_WITH_SUB_ELEMENTS_NUM_ELEMS);
+}
+
+void test_ut_kvp_getIterator_is_null_for_nonexistent_node(void)
+{
+    const char *nonexistentNodePath = "decodeTest/NonexistentNode";
+
+    ut_kvp_iterator_t *iter = ut_kvp_iterCreate(gpMainTestInstance, nonexistentNodePath);
+
+    UT_LOG_STEP("Tried to get iterator at nonexistent node %s", nonexistentNodePath);
+    UT_ASSERT(iter == NULL);
+}
+
+void test_ut_kvp_getIterator_is_null_for_nonsequence_node(void)
+{
+    const char *nonSequencePath = "decodeTest/notASequence";
+
+    ut_kvp_iterator_t *iter = ut_kvp_iterCreate(gpMainTestInstance, nonSequencePath);
+
+    UT_LOG_STEP("Tried to get iterator for non-sequence node at %s", nonSequencePath);
+    UT_ASSERT(iter == NULL);
+}
+
+bool callback_that_should_never_be_called(ut_kvp_instance_t *pInstance, void *userData)
+{
+    (void)pInstance;
+    (void)userData;
+
+    UT_ASSERT(false);
+    return false;
+}
+
+void test_ut_kvp_iterIterateForEmptySequence(void)
+{
+    const char *emptySequencePath = "decodeTest/emptySequence";
+
+    ut_kvp_iterator_t *iter = ut_kvp_iterCreate(gpMainTestInstance, emptySequencePath);
+
+    UT_LOG_STEP("Checking if we can create an iterator for an empty list, in: %s", emptySequencePath);
+    UT_ASSERT(iter != NULL);
+
+    ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iter, callback_that_should_never_be_called, NULL);
+
+    ut_kvp_iterDestroy(iter);
+
+    UT_LOG_STEP(
+        "Checking that iterResult (%" PRIu32 ") == %d and iterStatus (%d) == %d",
+        iterResult.iteration_count,
+        0,
+        (int)iterResult.status,
+        (int)UT_KVP_ITER_STATUS_FINISHED
+    );
+    UT_ASSERT(iterResult.iteration_count == 0); // checking number of iterations
+    UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_FINISHED); // checking status code
+}
+
+typedef struct {
+    uint32_t magic;
+} iter_fake_pointer;
+
+void test_ut_kvp_iterDestroy_does_nothing_on_other_pointers(void)
+{
+    const uint32_t stable = 0x57ab1e;
+
+    UT_LOG_STEP("Allocating fake iter pointer");
+    iter_fake_pointer *pFake = malloc(sizeof(iter_fake_pointer));
+    pFake->magic = stable;
+
+    UT_LOG_STEP("Calling ut_kvp_iterDestroy on fake iter pointer");
+    ut_kvp_iterDestroy((ut_kvp_iterator_t*)pFake);
+
+    UT_ASSERT(pFake->magic == stable);
+
+    UT_LOG_STEP("Deallocating fake iter pointer");
+    pFake->magic = 0;
+    free(pFake);
+}
+
+void test_ut_kvp_iterIterateStatusInvalidIterator(void)
+{
+    iter_fake_pointer *fakeIterator = malloc(sizeof(iter_fake_pointer));
+    fakeIterator->magic = 0x57ab1e;
+
+    ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(fakeIterator, NULL, NULL);
+
+    fakeIterator->magic = 0;
+    free(fakeIterator);
+
+    UT_ASSERT(iterResult.iteration_count == 0);
+    UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_INVALID_ITERATOR);
+}
+
+void test_ut_kvp_iterIterateStatusCallbackNull(void)
+{
+    const char *iterPath = "decodeTest/checkIterator";
+    ut_kvp_iterator_t *iterator = ut_kvp_iterCreate(gpMainTestInstance, iterPath);
+
+    ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iterator, NULL, NULL);
+
+    ut_kvp_iterDestroy(iterator);
+
+    UT_ASSERT(iterResult.iteration_count == 0);
+    UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_CALLBACK_IS_NULL);
+}
+
+bool callback_that_halts_at_id_0(ut_kvp_instance_t *pInstance, void *userData)
+{
+    int32_t id = ut_kvp_getInt32Field(pInstance, "id");
+
+    UT_LOG_STEP("Callback, element id: %" PRId32 " halting %d", id, id == 0);
+
+    if (id == 0)
+    {
+        return false;
+    } 
+    return true;
+}
+
+
+void test_ut_kvp_iterIterateCallbackReturnsFalseGivesStatusHalted(void)
+{
+    const char *iterPath = "decodeTest/checkIterator";
+    
+    ut_kvp_iterator_t *iterator = ut_kvp_iterCreate(gpMainTestInstance, iterPath);
+
+    ut_kvp_iter_result_t iterResult = ut_kvp_iterIterate(iterator, callback_that_halts_at_id_0, NULL);
+
+    ut_kvp_iterDestroy(iterator);
+
+
+    UT_ASSERT(iterResult.iteration_count == 1);
+    UT_ASSERT(iterResult.status == UT_KVP_ITER_STATUS_HALTED);
 }
 
 void test_ut_kvp_uint8(void)
@@ -1435,6 +1795,41 @@ static int test_ut_kvp_createGlobalYAMLInstanceForSequenceIncludeFileViaYaml( vo
 
 }
 
+static int test_ut_kvp_createGlobalYAMLInstanceForSequenceIteration( void)
+{
+    ut_kvp_status_t status;
+
+    gpMainTestInstance = ut_kvp_createInstance();
+    if ( gpMainTestInstance == NULL )
+    {
+        assert( gpMainTestInstance != NULL );
+        UT_LOG_ERROR("ut_kvp_open() - Read Failure");
+        return -1;
+    }
+
+    status = ut_kvp_open( gpMainTestInstance, KVP_VALID_TEST_SEQUENCE_ITERATION_YAML);
+    assert( status == UT_KVP_STATUS_SUCCESS );
+
+    if ( status != UT_KVP_STATUS_SUCCESS )
+    {
+        UT_LOG_ERROR("ut_kvp_open() - Read Failure");
+        return -1;
+    }
+
+    char* kvpData = ut_kvp_getData(gpMainTestInstance);
+
+    print_input_output(kvpData, KVP_VALID_TEST_SEQUENCE_ITERATION_YAML); // Print the emitted KVP string and input data from file
+
+    if(kvpData)
+    {
+        free(kvpData); // Free the emitted KVP string
+        kvpData = NULL;
+    }
+
+    return 0;
+
+}
+
 static int test_ut_kvp_createGlobalYAMLInstanceForMultipleProfileInputs( void)
 {
     /*Creating global instance for multiple profile support, so that the values
@@ -1606,4 +2001,36 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite12, "kvp bool from main yaml", test_ut_kvp_bool_on_main_yaml_for_sequence_includes);
     UT_add_test(gpKVPSuite12, "kvp node presence from main yaml", test_ut_kvp_fieldPresent_on_main_yaml_for_sequence_includes);
     UT_add_test(gpKVPSuite12, "kvp ssequence include support on malloc data", test_ut_kvp_ResolveAliasesAnchorsMergeKeysFromMallocedData);
+
+    gpKVPSuite13 = UT_add_suite(
+        "ut-kvp -  test main functions YAML Decoder for Yaml sequence "
+        "iteration support",
+        test_ut_kvp_createGlobalYAMLInstanceForSequenceIteration,
+        test_ut_kvp_freeGlobalInstance);
+    assert(gpKVPSuite13 != NULL);
+
+    UT_add_test(gpKVPSuite13, "Create Iterator with 2 elements",
+                test_ut_kvp_get_iterator_with_two_elements);
+    UT_add_test(gpKVPSuite13, "Create iterator from a path using dots",
+                test_ut_kvp_get_iterator_with_dotted_path);
+    UT_add_test(gpKVPSuite13, "Iterate Iterator",
+                test_ut_kvp_iterate_elements);
+    UT_add_test(gpKVPSuite13, "Iterate Iterator with sub-elements",
+                test_ut_kvp_iterate_elements_with_sub_elements);
+    UT_add_test(gpKVPSuite13, "Get Iterator returns null when node does not exist",
+                test_ut_kvp_getIterator_is_null_for_nonexistent_node);
+    UT_add_test(gpKVPSuite13, "Get Iterator returns null when node is not a sequence",
+                test_ut_kvp_getIterator_is_null_for_nonsequence_node);
+    UT_add_test(gpKVPSuite13, "Iter Free works only on ut_kvp_iterator_t",
+                test_ut_kvp_iterDestroy_does_nothing_on_other_pointers);
+    UT_add_test(gpKVPSuite13, "Iter Iterate invalid iterator gives invalid iterator status",
+                test_ut_kvp_iterIterateStatusInvalidIterator);
+    UT_add_test(gpKVPSuite13, "Iter Iterate callback null gives callback null iterator status",
+                test_ut_kvp_iterIterateStatusCallbackNull);
+    UT_add_test(gpKVPSuite13, "Iter Iterate on empty list is successful and never calls callback",
+                test_ut_kvp_iterIterateForEmptySequence);
+    UT_add_test(gpKVPSuite13, "Iter Iterate still works correctly if the source ut_kvp_instance is mutated",
+                test_ut_kvp_iterate_unaffected_by_mutation_of_ut_kvp_instance);
+    UT_add_test(gpKVPSuite13, "Iter Iterate returns halted when callback return is false",
+                test_ut_kvp_iterIterateCallbackReturnsFalseGivesStatusHalted);
 }


### PR DESCRIPTION
### Overview:

This PR introduces the following new functions, declared in `ut_kvp.h`

```C
ut_kvp_iterator_t *ut_kvp_iterCreate(ut_kvp_instance_t *pInstance, const char *pPath);
void ut_kvp_iterDestroy(ut_kvp_iterator_t *pIterator);
ut_kvp_iter_result_t ut_kvp_iterIterate(ut_kvp_iterator_t *pIterator, ut_kvp_iter_callback_t callback, void *userData);
```

Along with a few relevant datatypes.

Tests are in `tests/src/ut_test_kcp.c`

### Purpose:

This allows iteration across yaml lists/sequences which will make it easier to write parameterized tests, adding cases by expanding the lists in yaml.