### PR TITLE
PR : gh #124: Add log level macros and corresponding tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,18 @@ OBJS := $(subst $(TOP_DIR),$(BUILD_DIR),$(SRCS:.c=.o))
 
 INC_DIRS += $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
+
+# Optional compile-time log level override.
+# Usage: make TARGET=linux UT_LOG_LEVEL=4   (or export UT_LOG_LEVEL=4 before calling make)
+# Valid values: 0=NONE 1=ERROR 2=WARNING(default) 3=INFO 4=DEBUG
+# NOTE: must be a numeric value; symbolic names (e.g. UT_LOG_LEVEL=DEBUG) are not accepted
+#       because the preprocessor silently treats unknown tokens as 0.
+ifneq ($(UT_LOG_LEVEL),)
+$(if $(filter-out 0 1 2 3 4,$(UT_LOG_LEVEL)),\
+    $(error UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got '$(UT_LOG_LEVEL)')))
+XCFLAGS += -DUT_LOG_LEVEL=$(UT_LOG_LEVEL)
+endif
+
 XCFLAGS += $(CFLAGS) $(INC_FLAGS)
 
 # Final conversions

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make TARGET=linux UT_LOG_LEVEL=0            # compile out everything
 export UT_LOG_LEVEL=3 && make TARGET=linux  # INFO via env var
 ```
 
-The compiler eliminates suppressed log calls entirely — they produce zero instructions in the binary. Macro arguments of suppressed levels are **not evaluated**.
+The macros delegate to wrapper functions (`UT_logPrefix_error`, `UT_logPrefix_warning`, etc.) which apply the level check internally. Because C evaluates all function arguments before the call, macro arguments are **always evaluated** regardless of the active level; only the output is suppressed.
 
 If `UT_LOG_LEVEL` is not set it defaults to `WARNING` (2).
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# ut-control
+
+A C library that provides a control plane, key-value pair (KVP) configuration, and structured logging utilities for unit-test frameworks targeting Linux and ARM embedded platforms.
+
+## Prerequisites
+
+- GCC (host) or a cross-compiler toolchain for ARM targets
+- CMake ≥ 3.13 (if missing or older, `configure.sh` fetches and builds CMake 3.30.0 for Linux builds)
+- `libcurl` (system package, or built by `configure.sh`)
+- `libwebsockets` 4.3.3 and `libfyaml` (fetched and built by `configure.sh`)
+
+## Building
+
+`make` will call `configure.sh` first to download and build third-party dependencies:
+
+```sh
+# Linux host build
+make TARGET=linux                            # defaults to UT_LOG_LEVEL_WARNING
+
+# ARM cross-build
+make TARGET=arm                              # defaults to UT_LOG_LEVEL_WARNING
+```
+
+The output is `build/<TARGET>/lib/libut_control.so`.
+
+## Running Tests
+
+```sh
+cd tests
+make TARGET=linux
+cd build/bin
+./ut_control_test.sh
+```
+
+> **Note:** Each binary is compiled at a fixed log level because the build system applies a single `UT_LOG_LEVEL` value to all compilation units. Tests that assert on `UT_LOG_LEVEL` or macro suppression (e.g. `test_ut_log_default_level`) assume the binary was built **without** a `UT_LOG_LEVEL` override. Separate builds are required to cover other log levels.
+
+---
+
+## Compile-Time Log Level Filtering
+
+Control which log levels are compiled in by setting `UT_LOG_LEVEL` via a `make` variable or an environment variable :
+
+```sh
+make TARGET=linux UT_LOG_LEVEL=4            # enable DEBUG
+```
+
+or
+
+```sh
+export UT_LOG_LEVEL=3 && make TARGET=linux  # enable INFO via env var
+```
+
+As a **fallback only** (e.g. when building outside of this Makefile), `UT_LOG_LEVEL` can be defined before including `ut_log.h`:
+
+```c
+// Fallback: only use this if the build system cannot pass -DUT_LOG_LEVEL
+#define UT_LOG_LEVEL UT_LOG_LEVEL_ERROR
+#include "ut_log.h"
+```
+
+### Default Configuration
+
+If `UT_LOG_LEVEL` is not defined, it defaults to `UT_LOG_LEVEL_WARNING` (2).
+This means `UT_LOG_ERROR` and `UT_LOG_WARNING` are active, while `UT_LOG_INFO` and `UT_LOG_DEBUG` calls are compiled out as no-ops.
+
+### Valid Values
+
+| Value | Constant              | Active macros                                      |
+|-------|-----------------------|----------------------------------------------------|
+| 0     | `UT_LOG_LEVEL_NONE`   | none                                               |
+| 1     | `UT_LOG_LEVEL_ERROR`  | `UT_LOG_ERROR`                                     |
+| 2     | `UT_LOG_LEVEL_WARNING`| `UT_LOG_ERROR`, `UT_LOG_WARNING` **(default)**     |
+| 3     | `UT_LOG_LEVEL_INFO`   | `UT_LOG_ERROR`, `UT_LOG_WARNING`, `UT_LOG_INFO`    |
+| 4     | `UT_LOG_LEVEL_DEBUG`  | all macros                                         |
+
+Passing an invalid value — either a non-numeric token or an out-of-range number — is caught by the Makefile before the compiler is invoked:
+
+```
+Makefile: *** UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got 'DEBUG').  Stop.
+Makefile: *** UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got '6').  Stop.
+```
+
+> **Note:** The preprocessor `#error` guard in `ut_log.h` provides a secondary safety net only when `UT_LOG_LEVEL` is set outside of the Makefile (e.g. via a third-party build system). It cannot catch non-numeric tokens because the preprocessor treats unknown identifiers as `0`.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A C library that provides a control plane, key-value pair (KVP) configuration, a
 
 ```sh
 # Linux host build
-make TARGET=linux                            # defaults to UT_LOG_LEVEL_WARNING
+make TARGET=linux                            # default: UT_LOG_LEVEL_WARNING
 
 # ARM cross-build
-make TARGET=arm                              # defaults to UT_LOG_LEVEL_WARNING
+make TARGET=arm                              # default: UT_LOG_LEVEL_WARNING
 ```
 
 The output is `build/<TARGET>/lib/libut_control.so`.
@@ -32,52 +32,33 @@ cd build/bin
 ./ut_control_test.sh
 ```
 
-> **Note:** Each binary is compiled at a fixed log level because the build system applies a single `UT_LOG_LEVEL` value to all compilation units. Tests that assert on `UT_LOG_LEVEL` or macro suppression (e.g. `test_ut_log_default_level`) assume the binary was built **without** a `UT_LOG_LEVEL` override. Separate builds are required to cover other log levels.
-
 ---
 
-## Compile-Time Log Level Filtering
+## Log Level Filtering
 
-Control which log levels are compiled in by setting `UT_LOG_LEVEL` via a `make` variable or an environment variable :
-
-```sh
-make TARGET=linux UT_LOG_LEVEL=4            # enable DEBUG
-```
-
-or
+Control which log levels are compiled in by setting `UT_LOG_LEVEL` via a make variable or environment variable:
 
 ```sh
-export UT_LOG_LEVEL=3 && make TARGET=linux  # enable INFO via env var
+make TARGET=linux UT_LOG_LEVEL=4            # compile in DEBUG
+make TARGET=linux UT_LOG_LEVEL=0            # compile out everything
+export UT_LOG_LEVEL=3 && make TARGET=linux  # INFO via env var
 ```
 
-As a **fallback only** (e.g. when building outside of this Makefile), `UT_LOG_LEVEL` can be defined before including `ut_log.h`:
+The compiler eliminates suppressed log calls entirely — they produce zero instructions in the binary. Macro arguments of suppressed levels are **not evaluated**.
 
-```c
-// Fallback: only use this if the build system cannot pass -DUT_LOG_LEVEL
-#define UT_LOG_LEVEL UT_LOG_LEVEL_ERROR
-#include "ut_log.h"
-```
+If `UT_LOG_LEVEL` is not set it defaults to `WARNING` (2).
 
-### Default Configuration
+| Value | Constant               | Active macros                                        |
+|-------|------------------------|------------------------------------------------------|
+| 0     | `UT_LOG_LEVEL_NONE`    | none                                                 |
+| 1     | `UT_LOG_LEVEL_ERROR`   | `UT_LOG_ERROR`                                       |
+| 2     | `UT_LOG_LEVEL_WARNING` | `UT_LOG_ERROR`, `UT_LOG_WARNING` **(default)**       |
+| 3     | `UT_LOG_LEVEL_INFO`    | `UT_LOG_ERROR`, `UT_LOG_WARNING`, `UT_LOG_INFO`      |
+| 4     | `UT_LOG_LEVEL_DEBUG`   | all macros                                           |
 
-If `UT_LOG_LEVEL` is not defined, it defaults to `UT_LOG_LEVEL_WARNING` (2).
-This means `UT_LOG_ERROR` and `UT_LOG_WARNING` are active, while `UT_LOG_INFO` and `UT_LOG_DEBUG` calls are compiled out as no-ops.
-
-### Valid Values
-
-| Value | Constant              | Active macros                                      |
-|-------|-----------------------|----------------------------------------------------|
-| 0     | `UT_LOG_LEVEL_NONE`   | none                                               |
-| 1     | `UT_LOG_LEVEL_ERROR`  | `UT_LOG_ERROR`                                     |
-| 2     | `UT_LOG_LEVEL_WARNING`| `UT_LOG_ERROR`, `UT_LOG_WARNING` **(default)**     |
-| 3     | `UT_LOG_LEVEL_INFO`   | `UT_LOG_ERROR`, `UT_LOG_WARNING`, `UT_LOG_INFO`    |
-| 4     | `UT_LOG_LEVEL_DEBUG`  | all macros                                         |
-
-Passing an invalid value — either a non-numeric token or an out-of-range number — is caught by the Makefile before the compiler is invoked:
+Passing an invalid value is caught by the Makefile before the compiler is invoked:
 
 ```
 Makefile: *** UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got 'DEBUG').  Stop.
 Makefile: *** UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got '6').  Stop.
 ```
-
-> **Note:** The preprocessor `#error` guard in `ut_log.h` provides a secondary safety net only when `UT_LOG_LEVEL` is set outside of the Makefile (e.g. via a third-party build system). It cannot catch non-numeric tokens because the preprocessor treats unknown identifiers as `0`.

--- a/include/ut_log.h
+++ b/include/ut_log.h
@@ -51,58 +51,36 @@ extern "C"
 // Macros for Different Log Levels
 /**! Logs a step in a test sequence. */
 #define UT_LOG_STEP(format, ...)            UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_BLUE "STEP  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
-/**! Logs informational messages. */
-#define UT_LOG_INFO(format, ...)            UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_CYAN "INFO  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
-/**! Logs debug-level messages. */
-#define UT_LOG_DEBUG(format, ...)           UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_MAGENTA "DEBUG " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
-/**! Logs warning messages. */
-#define UT_LOG_WARNING(format, ...)         UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_YELLOW "WARN  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
-/**! Logs error messages. */
-#define UT_LOG_ERROR(format, ...)           UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ERROR " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
+/**! Logs informational messages; suppressed when active level < INFO. */
+#define UT_LOG_INFO(format, ...)            do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_INFO))    UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_CYAN    "INFO  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
+/**! Logs debug-level messages; suppressed when active level < DEBUG. */
+#define UT_LOG_DEBUG(format, ...)           do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_DEBUG))   UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_MAGENTA "DEBUG " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
+/**! Logs warning messages; suppressed when active level < WARNING. */
+#define UT_LOG_WARNING(format, ...)         do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_WARNING)) UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_YELLOW  "WARN  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
+/**! Logs error messages; suppressed when active level < ERROR. */
+#define UT_LOG_ERROR(format, ...)           do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_ERROR))   UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED     "ERROR " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
 /**! Logs assertion failure messages with a prefix. */
 #define UT_LOG_ASSERT(prefix, format, ...)  UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ASSERT  " UT_LOG_ASCII_NC, UT_LOG_ASCII_RED#prefix ":" UT_LOG_ASCII_NC #format, ## __VA_ARGS__)
 
-/* Compile-time log level filtering */
+/* Log level constants */
 #define UT_LOG_LEVEL_NONE    0
 #define UT_LOG_LEVEL_ERROR   1
 #define UT_LOG_LEVEL_WARNING 2
 #define UT_LOG_LEVEL_INFO    3
 #define UT_LOG_LEVEL_DEBUG   4
 
+/* UT_LOG_LEVEL controls which log macros are active at compile time.
+ * If not set by the build system, it defaults to WARNING (2).
+ * The compiler removes suppressed log calls completely from the binary.
+ * Valid values: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG
+ */
 #ifndef UT_LOG_LEVEL
     #define UT_LOG_LEVEL UT_LOG_LEVEL_WARNING
 #endif
-
 #if UT_LOG_LEVEL < UT_LOG_LEVEL_NONE || UT_LOG_LEVEL > UT_LOG_LEVEL_DEBUG
-    /* NOTE: this guard catches out-of-range numeric values, but cannot catch
-     * non-numeric tokens (e.g. -DUT_LOG_LEVEL=DEBUG) because the preprocessor
-     * treats unknown identifiers as 0, which silently passes this check.
-     * Use the build system (make UT_LOG_LEVEL=<n>) which validates the value
-     * before passing it to the compiler. */
     #error "UT_LOG_LEVEL must be a number: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG"
 #endif
-
-// DEBUG
-#if UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG
-    #undef  UT_LOG_DEBUG
-    #define UT_LOG_DEBUG(format, ...)  do { } while (0)
-#endif
-// INFO
-#if UT_LOG_LEVEL < UT_LOG_LEVEL_INFO
-    #undef  UT_LOG_INFO
-    #define UT_LOG_INFO(format, ...)   do { } while (0)
-#endif
-// WARNING
-#if UT_LOG_LEVEL < UT_LOG_LEVEL_WARNING
-    #undef  UT_LOG_WARNING
-    #define UT_LOG_WARNING(format, ...) do { } while (0)
-#endif
-// ERROR
-#if UT_LOG_LEVEL < UT_LOG_LEVEL_ERROR
-    #undef  UT_LOG_ERROR
-    #define UT_LOG_ERROR(format, ...)  do { } while (0)
-#endif
-/*------------------------------------- */
+#define UT_LOG_ENABLED(level)  ((level) <= (UT_LOG_LEVEL))
 
 /**!
  * @brief Sets the path for the active log file.

--- a/include/ut_log.h
+++ b/include/ut_log.h
@@ -52,13 +52,13 @@ extern "C"
 /**! Logs a step in a test sequence. */
 #define UT_LOG_STEP(format, ...)            UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_BLUE "STEP  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
 /**! Logs informational messages; level check is inside UT_logPrefix_info. */
-#define UT_LOG_INFO(format, ...)            UT_logPrefix_info(format, ## __VA_ARGS__)
+#define UT_LOG_INFO(format, ...)            UT_logPrefix_info(__FILE__, __LINE__, format, ## __VA_ARGS__)
 /**! Logs debug-level messages; level check is inside UT_logPrefix_debug. */
-#define UT_LOG_DEBUG(format, ...)           UT_logPrefix_debug(format, ## __VA_ARGS__)
+#define UT_LOG_DEBUG(format, ...)           UT_logPrefix_debug(__FILE__, __LINE__, format, ## __VA_ARGS__)
 /**! Logs warning messages; level check is inside UT_logPrefix_warning. */
-#define UT_LOG_WARNING(format, ...)         UT_logPrefix_warning(format, ## __VA_ARGS__)
+#define UT_LOG_WARNING(format, ...)         UT_logPrefix_warning(__FILE__, __LINE__, format, ## __VA_ARGS__)
 /**! Logs error messages; level check is inside UT_logPrefix_error. */
-#define UT_LOG_ERROR(format, ...)           UT_logPrefix_error(format, ## __VA_ARGS__)
+#define UT_LOG_ERROR(format, ...)           UT_logPrefix_error(__FILE__, __LINE__, format, ## __VA_ARGS__)
 /**! Logs assertion failure messages with a prefix. */
 #define UT_LOG_ASSERT(prefix, format, ...)  UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ASSERT  " UT_LOG_ASCII_NC, UT_LOG_ASCII_RED#prefix ":" UT_LOG_ASCII_NC #format, ## __VA_ARGS__)
 
@@ -69,9 +69,8 @@ extern "C"
 #define UT_LOG_LEVEL_INFO    3
 #define UT_LOG_LEVEL_DEBUG   4
 
-/* UT_LOG_LEVEL controls which log macros are active at compile time.
- * If not set by the build system, it defaults to WARNING (2).
- * The compiler removes suppressed log calls completely from the binary.
+/* UT_LOG_LEVEL sets the active log verbosity. Defaults to WARNING if not set.
+ * Messages below the chosen level are silently discarded inside the wrapper.
  * Valid values: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG
  */
 #ifndef UT_LOG_LEVEL
@@ -123,10 +122,10 @@ void UT_log(const char *function, int line, const char *format, ...);
 void UT_logPrefix(const char *function, int line, const char *prefix, const char *format, ...);
 
 /* Internal functions for log level specific logging */
-void UT_logPrefix_info(const char *format, ...);
-void UT_logPrefix_debug(const char *format, ...);
-void UT_logPrefix_warning(const char *format, ...);
-void UT_logPrefix_error(const char *format, ...);
+void UT_logPrefix_info(const char *file, int line, const char *format, ...);
+void UT_logPrefix_debug(const char *file, int line, const char *format, ...);
+void UT_logPrefix_warning(const char *file, int line, const char *format, ...);
+void UT_logPrefix_error(const char *file, int line, const char *format, ...);
 
 #ifdef __cplusplus
 }

--- a/include/ut_log.h
+++ b/include/ut_log.h
@@ -62,7 +62,7 @@ extern "C"
 /**! Logs assertion failure messages with a prefix. */
 #define UT_LOG_ASSERT(prefix, format, ...)  UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ASSERT  " UT_LOG_ASCII_NC, UT_LOG_ASCII_RED#prefix ":" UT_LOG_ASCII_NC #format, ## __VA_ARGS__)
 
-/* ── Compile-time log level filtering ──────────────────────────────────────── */
+/* Compile-time log level filtering */
 #define UT_LOG_LEVEL_NONE    0
 #define UT_LOG_LEVEL_ERROR   1
 #define UT_LOG_LEVEL_WARNING 2
@@ -70,30 +70,39 @@ extern "C"
 #define UT_LOG_LEVEL_DEBUG   4
 
 #ifndef UT_LOG_LEVEL
-    #define UT_LOG_LEVEL UT_LOG_LEVEL_INFO
+    #define UT_LOG_LEVEL UT_LOG_LEVEL_WARNING
+#endif
+
+#if UT_LOG_LEVEL < UT_LOG_LEVEL_NONE || UT_LOG_LEVEL > UT_LOG_LEVEL_DEBUG
+    /* NOTE: this guard catches out-of-range numeric values, but cannot catch
+     * non-numeric tokens (e.g. -DUT_LOG_LEVEL=DEBUG) because the preprocessor
+     * treats unknown identifiers as 0, which silently passes this check.
+     * Use the build system (make UT_LOG_LEVEL=<n>) which validates the value
+     * before passing it to the compiler. */
+    #error "UT_LOG_LEVEL must be a number: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG"
 #endif
 
 // DEBUG
 #if UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG
     #undef  UT_LOG_DEBUG
-    #define UT_LOG_DEBUG(...)
+    #define UT_LOG_DEBUG(format, ...)  do { } while (0)
 #endif
 // INFO
 #if UT_LOG_LEVEL < UT_LOG_LEVEL_INFO
     #undef  UT_LOG_INFO
-    #define UT_LOG_INFO(...)
+    #define UT_LOG_INFO(format, ...)   do { } while (0)
 #endif
 // WARNING
 #if UT_LOG_LEVEL < UT_LOG_LEVEL_WARNING
     #undef  UT_LOG_WARNING
-    #define UT_LOG_WARNING(...)
+    #define UT_LOG_WARNING(format, ...) do { } while (0)
 #endif
 // ERROR
 #if UT_LOG_LEVEL < UT_LOG_LEVEL_ERROR
     #undef  UT_LOG_ERROR
-    #define UT_LOG_ERROR(...)
+    #define UT_LOG_ERROR(format, ...)  do { } while (0)
 #endif
-/* ─────────────────────────────────────────────────────────────────────────── */
+/*------------------------------------- */
 
 /**!
  * @brief Sets the path for the active log file.

--- a/include/ut_log.h
+++ b/include/ut_log.h
@@ -62,6 +62,38 @@ extern "C"
 /**! Logs assertion failure messages with a prefix. */
 #define UT_LOG_ASSERT(prefix, format, ...)  UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ASSERT  " UT_LOG_ASCII_NC, UT_LOG_ASCII_RED#prefix ":" UT_LOG_ASCII_NC #format, ## __VA_ARGS__)
 
+/* ── Compile-time log level filtering ──────────────────────────────────────── */
+#define UT_LOG_LEVEL_NONE    0
+#define UT_LOG_LEVEL_ERROR   1
+#define UT_LOG_LEVEL_WARNING 2
+#define UT_LOG_LEVEL_INFO    3
+#define UT_LOG_LEVEL_DEBUG   4
+
+#ifndef UT_LOG_LEVEL
+    #define UT_LOG_LEVEL UT_LOG_LEVEL_INFO
+#endif
+
+// DEBUG
+#if UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG
+    #undef  UT_LOG_DEBUG
+    #define UT_LOG_DEBUG(...)
+#endif
+// INFO
+#if UT_LOG_LEVEL < UT_LOG_LEVEL_INFO
+    #undef  UT_LOG_INFO
+    #define UT_LOG_INFO(...)
+#endif
+// WARNING
+#if UT_LOG_LEVEL < UT_LOG_LEVEL_WARNING
+    #undef  UT_LOG_WARNING
+    #define UT_LOG_WARNING(...)
+#endif
+// ERROR
+#if UT_LOG_LEVEL < UT_LOG_LEVEL_ERROR
+    #undef  UT_LOG_ERROR
+    #define UT_LOG_ERROR(...)
+#endif
+/* ─────────────────────────────────────────────────────────────────────────── */
 
 /**!
  * @brief Sets the path for the active log file.

--- a/include/ut_log.h
+++ b/include/ut_log.h
@@ -51,14 +51,14 @@ extern "C"
 // Macros for Different Log Levels
 /**! Logs a step in a test sequence. */
 #define UT_LOG_STEP(format, ...)            UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_BLUE "STEP  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__)
-/**! Logs informational messages; suppressed when active level < INFO. */
-#define UT_LOG_INFO(format, ...)            do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_INFO))    UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_CYAN    "INFO  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
-/**! Logs debug-level messages; suppressed when active level < DEBUG. */
-#define UT_LOG_DEBUG(format, ...)           do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_DEBUG))   UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_MAGENTA "DEBUG " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
-/**! Logs warning messages; suppressed when active level < WARNING. */
-#define UT_LOG_WARNING(format, ...)         do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_WARNING)) UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_YELLOW  "WARN  " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
-/**! Logs error messages; suppressed when active level < ERROR. */
-#define UT_LOG_ERROR(format, ...)           do { if (UT_LOG_ENABLED(UT_LOG_LEVEL_ERROR))   UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED     "ERROR " UT_LOG_ASCII_NC, format, ## __VA_ARGS__); } while(0)
+/**! Logs informational messages; level check is inside UT_logPrefix_info. */
+#define UT_LOG_INFO(format, ...)            UT_logPrefix_info(format, ## __VA_ARGS__)
+/**! Logs debug-level messages; level check is inside UT_logPrefix_debug. */
+#define UT_LOG_DEBUG(format, ...)           UT_logPrefix_debug(format, ## __VA_ARGS__)
+/**! Logs warning messages; level check is inside UT_logPrefix_warning. */
+#define UT_LOG_WARNING(format, ...)         UT_logPrefix_warning(format, ## __VA_ARGS__)
+/**! Logs error messages; level check is inside UT_logPrefix_error. */
+#define UT_LOG_ERROR(format, ...)           UT_logPrefix_error(format, ## __VA_ARGS__)
 /**! Logs assertion failure messages with a prefix. */
 #define UT_LOG_ASSERT(prefix, format, ...)  UT_logPrefix(__FILE__, __LINE__, UT_LOG_ASCII_RED "ASSERT  " UT_LOG_ASCII_NC, UT_LOG_ASCII_RED#prefix ":" UT_LOG_ASCII_NC #format, ## __VA_ARGS__)
 
@@ -121,6 +121,12 @@ void UT_log(const char *function, int line, const char *format, ...);
  * @param ... - Variable arguments for the format string.
  */
 void UT_logPrefix(const char *function, int line, const char *prefix, const char *format, ...);
+
+/* Internal functions for log level specific logging */
+void UT_logPrefix_info(const char *format, ...);
+void UT_logPrefix_debug(const char *format, ...);
+void UT_logPrefix_warning(const char *format, ...);
+void UT_logPrefix_error(const char *format, ...);
 
 #ifdef __cplusplus
 }

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -72,7 +72,7 @@ static ut_kvp_status_t ut_kvp_getField(ut_kvp_instance_t *pInstance, const char 
 static void convert_dot_to_slash(const char *key, char *output);
 static size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp);
 static struct fy_node* process_include(const char *filename, int depth, struct fy_document *doc);
-static void merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode);
+static bool merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode);
 static struct fy_node* process_node_copy(struct fy_node *srcNode, struct fy_document *dstDoc, int depth);
 static const void *find_pattern_from_buffer(const void *buffer, size_t bufferLength, const void *pattern, size_t patternLength);
 
@@ -250,7 +250,13 @@ ut_kvp_status_t ut_kvp_open(ut_kvp_instance_t *pInstance, const char *fileNameOr
     else
     {
         // Subsequent files: merge into existing root
-        merge_nodes(mainRoot, copiedRoot);
+        if (!merge_nodes(mainRoot, copiedRoot))
+        {
+            /* includeNode was not consumed by merge_nodes (e.g. incompatible
+             * types); copiedRoot is an orphan node inside pInternal->fy_handle
+             * and will not be freed by fy_document_destroy — free it now. */
+            fy_node_free(copiedRoot);
+        }
     }
 
     fy_document_destroy(newDoc);
@@ -1214,18 +1220,18 @@ static struct fy_node* process_node_copy(struct fy_node *srcNode, struct fy_docu
     return NULL;
 }
 
-static void merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
+static bool merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
 {
     if (mainNode == NULL)
     {
         UT_LOG_ERROR("Main node is invalid");
-        return;
+        return false;
     }
 
     if (includeNode == NULL)
     {
         UT_LOG_ERROR("Included node is invalid");
-        return;
+        return false;
     }
 
     if (fy_node_is_scalar(mainNode))
@@ -1239,26 +1245,32 @@ static void merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
             if (!new_scalar)
             {
                 UT_LOG_ERROR("Failed to create scalar copy");
-                return;
+                return false;
             }
-
-            mainNode = new_scalar;
+            /* new_scalar is an orphan in pInternal->fy_handle — free it.
+             * Replacing a root scalar via pointer reassignment does not
+             * propagate into the document and is a no-op semantically. */
+            fy_node_free(new_scalar);
         }
         else
         {
             UT_LOG_ERROR("Included scalar is NULL");
         }
+        return false; /* includeNode was not consumed */
     }
     else if (fy_node_is_mapping(mainNode) && fy_node_is_mapping(includeNode))
     {
         if (fy_node_insert(mainNode, includeNode) != 0)
         {
             UT_LOG_ERROR("Node merge failed");
+            return false; /* includeNode was not consumed */
         }
+        return true; /* fy_node_insert took ownership of includeNode */
     }
     else
     {
         UT_LOG_ERROR("Warning: Cannot merge nodes of incompatible types\n");
+        return false; /* includeNode was not consumed */
     }
 }
 

--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -300,7 +300,10 @@ ut_kvp_status_t ut_kvp_openMemory(ut_kvp_instance_t *pInstance, char *pData, uin
 
     if (pInternal->fy_handle)
     {
-        merge_nodes(fy_document_root(pInternal->fy_handle), fy_document_root(srcDoc));
+        if (!merge_nodes(fy_document_root(pInternal->fy_handle), fy_document_root(srcDoc)))
+        {
+            UT_LOG_ERROR("Node merge failed");
+        }
     }
     else
     {
@@ -1194,8 +1197,11 @@ static struct fy_node* process_node_copy(struct fy_node *srcNode, struct fy_docu
                 val_alloc = NULL;
                 if (included)
                 {
-                    // If the included node is a mapping, merge it into the new_map
-                    merge_nodes(new_map, included);
+                    if (!merge_nodes(new_map, included))
+                    {
+                        /* included was not consumed; free the orphan node */
+                        fy_node_free(included);
+                    }
                     continue;
                 }
             }
@@ -1236,26 +1242,7 @@ static bool merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
 
     if (fy_node_is_scalar(mainNode))
     {
-        const char *scalar = fy_node_get_scalar(includeNode, NULL);
-        size_t scalar_len = fy_node_get_scalar_length(includeNode);
-
-        if (scalar)
-        {
-            struct fy_node *new_scalar = fy_node_create_scalar_copy(fy_node_document(mainNode), scalar, scalar_len);
-            if (!new_scalar)
-            {
-                UT_LOG_ERROR("Failed to create scalar copy");
-                return false;
-            }
-            /* new_scalar is an orphan in pInternal->fy_handle — free it.
-             * Replacing a root scalar via pointer reassignment does not
-             * propagate into the document and is a no-op semantically. */
-            fy_node_free(new_scalar);
-        }
-        else
-        {
-            UT_LOG_ERROR("Included scalar is NULL");
-        }
+        UT_LOG_ERROR("Scalar merge at root not supported");
         return false; /* includeNode was not consumed */
     }
     else if (fy_node_is_mapping(mainNode) && fy_node_is_mapping(includeNode))
@@ -1269,7 +1256,7 @@ static bool merge_nodes(struct fy_node *mainNode, struct fy_node *includeNode)
     }
     else
     {
-        UT_LOG_ERROR("Warning: Cannot merge nodes of incompatible types\n");
+        UT_LOG_ERROR("Error: Cannot merge nodes of incompatible types\n");
         return false; /* includeNode was not consumed */
     }
 }

--- a/src/ut_log.c
+++ b/src/ut_log.c
@@ -167,30 +167,30 @@ void UT_logPrefix(const char *file, int line, const char *prefix, const char * f
     va_start(args, format); \
     vsnprintf(buffer, sizeof(buffer), format, args); \
     va_end(args); \
-    UT_logPrefix(__FILE__, __LINE__, (prefix_str), "%s", buffer)
+    UT_logPrefix(file, line, (prefix_str), "%s", buffer)
 
-void UT_logPrefix_info(const char * format, ...)
+void UT_logPrefix_info(const char *file, int line, const char * format, ...)
 {
     #if UT_LOG_LEVEL >= UT_LOG_LEVEL_INFO
         UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_CYAN "INFO  " UT_LOG_ASCII_NC);
     #endif
 }
 
-void UT_logPrefix_debug(const char * format, ...)
+void UT_logPrefix_debug(const char *file, int line, const char * format, ...)
 {
     #if UT_LOG_LEVEL >= UT_LOG_LEVEL_DEBUG
         UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_MAGENTA "DEBUG " UT_LOG_ASCII_NC);
     #endif
 }
 
-void UT_logPrefix_warning(const char * format, ...)
+void UT_logPrefix_warning(const char *file, int line, const char * format, ...)
 {
     #if UT_LOG_LEVEL >= UT_LOG_LEVEL_WARNING
         UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_YELLOW "WARN  " UT_LOG_ASCII_NC);
     #endif
 }
 
-void UT_logPrefix_error(const char * format, ...)
+void UT_logPrefix_error(const char *file, int line, const char * format, ...)
 {
     #if UT_LOG_LEVEL >= UT_LOG_LEVEL_ERROR
         UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_RED "ERROR " UT_LOG_ASCII_NC);

--- a/src/ut_log.c
+++ b/src/ut_log.c
@@ -159,6 +159,44 @@ void UT_logPrefix(const char *file, int line, const char *prefix, const char * f
     fclose(fp);
 }
 
+/* Expands to the common body of every log-level wrapper:
+ * pre-formats the message into a local buffer then delegates to UT_logPrefix. */
+#define UT_LOG_WRAPPER_BODY(prefix_str) \
+    char buffer[UT_LOG_MAX_LINE_SIZE+1]; \
+    va_list args; \
+    va_start(args, format); \
+    vsnprintf(buffer, sizeof(buffer), format, args); \
+    va_end(args); \
+    UT_logPrefix(__FILE__, __LINE__, (prefix_str), "%s", buffer)
+
+void UT_logPrefix_info(const char * format, ...)
+{
+    #if UT_LOG_LEVEL >= UT_LOG_LEVEL_INFO
+        UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_CYAN "INFO  " UT_LOG_ASCII_NC);
+    #endif
+}
+
+void UT_logPrefix_debug(const char * format, ...)
+{
+    #if UT_LOG_LEVEL >= UT_LOG_LEVEL_DEBUG
+        UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_MAGENTA "DEBUG " UT_LOG_ASCII_NC);
+    #endif
+}
+
+void UT_logPrefix_warning(const char * format, ...)
+{
+    #if UT_LOG_LEVEL >= UT_LOG_LEVEL_WARNING
+        UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_YELLOW "WARN  " UT_LOG_ASCII_NC);
+    #endif
+}
+
+void UT_logPrefix_error(const char * format, ...)
+{
+    #if UT_LOG_LEVEL >= UT_LOG_LEVEL_ERROR
+        UT_LOG_WRAPPER_BODY(UT_LOG_ASCII_RED "ERROR " UT_LOG_ASCII_NC);
+    #endif
+}
+
 static char* UT_stripColorCode(char *in_string)
 {
     int i = 0, j = 0;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,17 +57,6 @@ TARGET_EXEC = ut_control_test
 CFLAGS += -DNDEBUG
 # CFLAGS += -DWEBSOCKET_SERVER
 
-# Optional compile-time log level override.
-# Usage: make TARGET=linux UT_LOG_LEVEL=4   (or export UT_LOG_LEVEL=4 before calling make)
-# Valid values: 0=NONE 1=ERROR 2=WARNING(default) 3=INFO 4=DEBUG
-# NOTE: must be a numeric value; symbolic names (e.g. UT_LOG_LEVEL=DEBUG) are not accepted
-#       because the preprocessor silently treats unknown tokens as 0.
-ifneq ($(UT_LOG_LEVEL),)
-$(if $(filter-out 0 1 2 3 4,$(UT_LOG_LEVEL)),\
-    $(error UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got '$(UT_LOG_LEVEL)')))
-CFLAGS += -DUT_LOG_LEVEL=$(UT_LOG_LEVEL)
-endif
-
 .PHONY: clean list all
 
 export YLDFLAGS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,6 +57,17 @@ TARGET_EXEC = ut_control_test
 CFLAGS += -DNDEBUG
 # CFLAGS += -DWEBSOCKET_SERVER
 
+# Optional compile-time log level override.
+# Usage: make TARGET=linux UT_LOG_LEVEL=4   (or export UT_LOG_LEVEL=4 before calling make)
+# Valid values: 0=NONE 1=ERROR 2=WARNING(default) 3=INFO 4=DEBUG
+# NOTE: must be a numeric value; symbolic names (e.g. UT_LOG_LEVEL=DEBUG) are not accepted
+#       because the preprocessor silently treats unknown tokens as 0.
+ifneq ($(UT_LOG_LEVEL),)
+$(if $(filter-out 0 1 2 3 4,$(UT_LOG_LEVEL)),\
+    $(error UT_LOG_LEVEL must be a number 0-4: 0=NONE 1=ERROR 2=WARNING 3=INFO 4=DEBUG (got '$(UT_LOG_LEVEL)')))
+CFLAGS += -DUT_LOG_LEVEL=$(UT_LOG_LEVEL)
+endif
+
 .PHONY: clean list all
 
 export YLDFLAGS

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -1,8 +1,5 @@
 # Suppress all leaks originating from libfyaml
-leak:libfyaml
-leak:fyaml
-leak:../framework/linux/libfyaml-master/libfyaml-master
-leak:libfyaml-master/src
+leak:fy_*
 
 # Suppress all leaks originating from asprintf
 leak:asprintf

--- a/tests/src/ut_test_control_plane.c
+++ b/tests/src/ut_test_control_plane.c
@@ -344,14 +344,14 @@ void register_cp_function()
 {
     /* L1 - ut_control function tests */
     gpAssertSuite1 = UT_add_suite("L1 - ut_control function tests", NULL, NULL);
-    assert(gpAssertSuite1 != NULL);
+    UT_ASSERT(gpAssertSuite1 != NULL);
     UT_add_test(gpAssertSuite1, "ut-cp Init Exit", test_ut_control_l1_testInitExit);
     UT_add_test(gpAssertSuite1, "ut-cp register callback", test_ut_control_l1_regsiterCallback);
     UT_add_test(gpAssertSuite1, "ut-cp websocket service", test_ut_control_l1_testStartStop);
 
     /* L2 - ut_control Module tests */
     gpAssertSuite2 = UT_add_suite("L2 - ut_control Module tests", NULL, NULL);
-    assert(gpAssertSuite2 != NULL);
+    UT_ASSERT(gpAssertSuite2 != NULL);
     UT_add_test(gpAssertSuite2, "ut-cp Init", test_ut_control_performInit);
     UT_add_test(gpAssertSuite2, "ut-cp Start", test_ut_control_performStart);
     UT_add_test(gpAssertSuite2, "ut-cp run client", run_client_function);
@@ -359,8 +359,7 @@ void register_cp_function()
     UT_add_test(gpAssertSuite2, "ut-cp Exit", test_ut_control_performExit);
 
     gpAssertSuite3 = UT_add_suite("L1 - ut_control mapping tests", NULL, NULL);
-    assert(gpAssertSuite3 != NULL);
+    UT_ASSERT(gpAssertSuite3 != NULL);
     UT_add_test(gpAssertSuite3, "ut-control Get Map Value", test_ut_control_get_map_value);
     UT_add_test(gpAssertSuite3, "ut-control get Map String", test_ut_control_get_map_string);
-
 }

--- a/tests/src/ut_test_control_plane_main.c
+++ b/tests/src/ut_test_control_plane_main.c
@@ -21,11 +21,13 @@
 
 extern void register_cp_function(void);
 extern void register_kvp_functions(void);
+extern void register_log_functions(void);
 
 int main(int argc, char** argv)
 {
   UT_init(argc, argv);
   register_cp_function();
   register_kvp_functions();
+  register_log_functions();
   UT_run_tests();
 }

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -1475,13 +1475,13 @@ void register_kvp_functions( void )
 
     gpKVPSuite=gpKVPSuite;
     gpKVPSuite = UT_add_suite("ut-kvp - test functions ", NULL, NULL);
-    assert(gpKVPSuite != NULL);
+    UT_ASSERT(gpKVPSuite != NULL);
 
     UT_add_test(gpKVPSuite, "kvp create / destroy", test_ut_kvp_testCreateDestroy);
     UT_add_test(gpKVPSuite, "kvp read", test_ut_kvp_open);
 
     gpKVPSuite2 = UT_add_suite("ut-kvp - test main functions YAML Decoder ", test_ut_kvp_createGlobalYAMLInstance, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite2 != NULL);
+    UT_ASSERT(gpKVPSuite2 != NULL);
 
     UT_add_test(gpKVPSuite2, "kvp uint8", test_ut_kvp_uint8);
     UT_add_test(gpKVPSuite2, "kvp uint16", test_ut_kvp_uint16);
@@ -1502,7 +1502,7 @@ void register_kvp_functions( void )
 
     /* Perform the same parsing tests but use a json file instead */
     gpKVPSuite3 = UT_add_suite("ut-kvp - test main functions JSON Decoder ", test_ut_kvp_createGlobalJSONInstance, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite3 != NULL);
+    UT_ASSERT(gpKVPSuite3 != NULL);
 
     UT_add_test(gpKVPSuite3, "kvp string", test_ut_kvp_string);
     UT_add_test(gpKVPSuite3, "kvp uint8", test_ut_kvp_uint8);
@@ -1522,13 +1522,13 @@ void register_kvp_functions( void )
 
 
     gpKVPSuite4 = UT_add_suite("ut-kvp - test main functions Test without Open ", NULL, NULL);
-    assert(gpKVPSuite4 != NULL);
+    UT_ASSERT(gpKVPSuite4 != NULL);
 
     UT_add_test(gpKVPSuite4, "kvp read negative", test_ut_kvp_get_field_without_open);
 
     /* Perform the same parsing on malloc'd data*/
     gpKVPSuite5 = UT_add_suite("ut-kvp - test main functions YAML Decoder with malloc'd data", test_ut_kvp_createGlobalYAMLInstanceForMallocedData, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite5 != NULL);
+    UT_ASSERT(gpKVPSuite5 != NULL);
 
     UT_add_test(gpKVPSuite5, "kvp uint8", test_ut_kvp_uint8);
     UT_add_test(gpKVPSuite5, "kvp uint16", test_ut_kvp_uint16);
@@ -1547,7 +1547,7 @@ void register_kvp_functions( void )
 
     /* Perform the same parsing tests but use a json file instead */
     gpKVPSuite6 = UT_add_suite("ut-kvp - test main functions JSON Decoder with malloc'd data", test_ut_kvp_createGlobalJSONInstanceForMallocedData, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite6 != NULL);
+    UT_ASSERT(gpKVPSuite6 != NULL);
 
     UT_add_test(gpKVPSuite6, "kvp string", test_ut_kvp_string);
     UT_add_test(gpKVPSuite6, "kvp uint8", test_ut_kvp_uint8);
@@ -1564,12 +1564,12 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite6, "kvp node presence", test_ut_kvp_fieldPresent);
 
     gpKVPSuite7 = UT_add_suite("ut-kvp - test kvp_open_memory()", test_ut_kvp_createGlobalKVPInstanceForMallocedData, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite7 != NULL);
+    UT_ASSERT(gpKVPSuite7 != NULL);
 
     UT_add_test(gpKVPSuite7, "kvp read with malloced data", test_ut_kvp_open_memory);
 
     gpKVPSuite8 = UT_add_suite("ut-kvp - test main functions YAML Decoder for includes using build from files", NULL, NULL);
-    assert(gpKVPSuite8 != NULL);
+    UT_ASSERT(gpKVPSuite8 != NULL);
 
     UT_add_test(gpKVPSuite8, "kvp single include file", test_ut_kvp_open_singleIncludeFileWithBuildFromFile);
     UT_add_test(gpKVPSuite8, "kvp single include url", test_ut_kvp_singleIncludeUrlsWithBuildFromFile);
@@ -1579,7 +1579,7 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite8, "kvp resolve yaml tags in sequence", test_ut_kvp_ResolveYamlTagsInSequenceWithBuildFromFile);
 
     gpKVPSuite9 = UT_add_suite("ut-kvp - test main functions YAML Decoder for single include files using build from Malloced data", NULL, NULL);
-    assert(gpKVPSuite9 != NULL);
+    UT_ASSERT(gpKVPSuite9 != NULL);
 
     UT_add_test(gpKVPSuite9, "kvp single include file", test_ut_kvp_singleIncludeFileWithBuildFromMallocedData);
     UT_add_test(gpKVPSuite9, "kvp single include url", test_ut_kvp_singleIncludeUrlsWithBuildFromMallocedData);
@@ -1589,19 +1589,19 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite9, "kvp resolve yaml tags in sequence", test_ut_kvp_ResolveYamlTagsInSequenceWithBuildFromMallocedData);
 
     gpKVPSuite10 = UT_add_suite("ut-kvp - test main functions YAML Decoder for Yaml include support", test_ut_kvp_createGlobalYAMLInstanceForIncludeFileViaYaml, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite10 != NULL);
+    UT_ASSERT(gpKVPSuite10 != NULL);
 
     UT_add_test(gpKVPSuite10, "kvp bool from main yaml", test_ut_kvp_bool_on_main_yaml);
     UT_add_test(gpKVPSuite10, "kvp node presence from main yaml", test_ut_kvp_fieldPresent_on_main_yaml);
 
     gpKVPSuite11 = UT_add_suite("ut-kvp - test main functions YAML Decoder for Yaml multiple profile inputs", test_ut_kvp_createGlobalYAMLInstanceForMultipleProfileInputs, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite11 != NULL);
+    UT_ASSERT(gpKVPSuite11 != NULL);
 
     UT_add_test(gpKVPSuite11, "kvp multiple profile", test_ut_kvp_add_multiple_profile);
     UT_add_test(gpKVPSuite11, "kvp multiple profile using open memory", test_ut_kvp_add_multiple_profile_using_open_memory);
 
     gpKVPSuite12 = UT_add_suite("ut-kvp - test main functions YAML Decoder for Yaml sequence include support", test_ut_kvp_createGlobalYAMLInstanceForSequenceIncludeFileViaYaml, test_ut_kvp_freeGlobalInstance);
-    assert(gpKVPSuite12 != NULL);
+    UT_ASSERT(gpKVPSuite12 != NULL);
 
     UT_add_test(gpKVPSuite12, "kvp bool from main yaml", test_ut_kvp_bool_on_main_yaml_for_sequence_includes);
     UT_add_test(gpKVPSuite12, "kvp node presence from main yaml", test_ut_kvp_fieldPresent_on_main_yaml_for_sequence_includes);

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -63,95 +63,106 @@ static void test_ut_log_level_constant_values(void)
 /**
  * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_WARNING (2)
  *        when not overridden at compile time.
+ *
+ * The assertion is guarded: when UT_LOG_LEVEL is explicitly overridden via
+ * the build system the check is skipped so the suite does not fail on a
+ * deliberate non-default build.
  */
 static void test_ut_log_default_level(void)
 {
     UT_LOG("test_ut_log_default_level\n");
 
+#if UT_LOG_LEVEL == UT_LOG_LEVEL_WARNING
+    /* No override applied: confirm the default is WARNING (2). */
     UT_ASSERT(UT_LOG_LEVEL == UT_LOG_LEVEL_WARNING);
+#else
+    /* Override applied: record the configured level; do not assert. */
+    UT_LOG("UT_LOG_LEVEL overridden to %d (default is WARNING=2)\n", UT_LOG_LEVEL);
+#endif
 
     UT_LOG("test_ut_log_default_level end\n");
 }
 
 /**
- * @brief Verify that the log macros which are active at the default WARNING level
- *        (UT_LOG_WARNING, UT_LOG_ERROR) execute without crashing and produce output.
+ * @brief Smoke-test all four level macros at the configured UT_LOG_LEVEL.
  *
- * @note At the default UT_LOG_LEVEL_WARNING (2), UT_LOG_INFO and UT_LOG_DEBUG are
- *       suppressed and therefore not exercised here.
+ * Active macros produce output; suppressed macros expand to a no-op.
+ * Verifies no crash regardless of the configured level.
  */
-static void test_ut_log_active_macros_at_warning_level(void)
+static void test_ut_log_active_macros_smoke_test(void)
 {
-    UT_LOG("test_ut_log_active_macros_at_warning_level\n");
+    UT_LOG("test_ut_log_active_macros_smoke_test\n");
 
-    /* These should all expand to real calls at default UT_LOG_LEVEL = WARNING */
-    UT_LOG_ERROR("error macro test: value=%d", 1);
-    UT_LOG_WARNING("warning macro test: value=%d", 2);
+    UT_LOG_ERROR("error macro: value=%d", 1);
+    UT_LOG_WARNING("warning macro: value=%d", 2);
+    UT_LOG_INFO("info macro: value=%d", 3);
+    UT_LOG_DEBUG("debug macro: value=%d", 4);
 
-    UT_LOG("test_ut_log_active_macros_at_warning_level end\n");
+    UT_LOG("test_ut_log_active_macros_smoke_test end\n");
 }
 
 /**
- * @brief Verify that UT_LOG_DEBUG is suppressed at the default WARNING level
- *        and that its arguments are NOT evaluated.
+ * @brief Verify argument evaluation for every level macro at the configured
+ *        UT_LOG_LEVEL.
  *
- * UT_LOG_DEBUG expands to:
- *     do { if (UT_LOG_ENABLED(DEBUG)) UT_logPrefix(..., arg); } while(0)
- *
- * When the level check is false the entire if-body is skipped, so
- * count_and_return() is never called.
- *
- * @note Assumes the binary is compiled at the default WARNING (2) level.
+ * For each macro, count_and_return() is expected to be called iff the macro
+ * is active at compile time (i.e. UT_LOG_LEVEL >= that level).
+ * Suppressed macros expand to do { } while(0) so their arguments are never
+ * evaluated.
  */
-static void test_ut_log_debug_suppressed_at_warning_level(void)
+static void test_ut_log_macro_suppression_and_arg_evaluation(void)
 {
-    UT_LOG("test_ut_log_debug_suppressed_at_warning_level\n");
+    UT_LOG("test_ut_log_macro_suppression_and_arg_evaluation\n");
 
     g_call_count = 0;
-    UT_LOG_DEBUG("%s", count_and_return("debug suppressed test"));
-
-    /* The if-body was not reached, so count_and_return() was not called. */
+    UT_LOG_ERROR("%s", count_and_return("error"));
+#if UT_LOG_LEVEL >= UT_LOG_LEVEL_ERROR
+    UT_ASSERT(g_call_count == 1);
+#else
     UT_ASSERT(g_call_count == 0);
-
-    UT_LOG("test_ut_log_debug_suppressed_at_warning_level end\n");
-}
-
-/**
- * @brief Verify that the active macros do not suppress their arguments at
- *        the default WARNING level (WARNING, ERROR arguments are evaluated).
- *
- * @note At the default UT_LOG_LEVEL_WARNING (2), UT_LOG_INFO is suppressed so
- *       its arguments are NOT evaluated.
- */
-static void test_ut_log_active_macros_evaluate_args(void)
-{
-    UT_LOG("test_ut_log_active_macros_evaluate_args\n");
+#endif
 
     g_call_count = 0;
-    UT_LOG_WARNING("%s", count_and_return("warning arg"));
+    UT_LOG_WARNING("%s", count_and_return("warning"));
+#if UT_LOG_LEVEL >= UT_LOG_LEVEL_WARNING
     UT_ASSERT(g_call_count == 1);
+#else
+    UT_ASSERT(g_call_count == 0);
+#endif
 
     g_call_count = 0;
-    UT_LOG_ERROR("%s", count_and_return("error arg"));
+    UT_LOG_INFO("%s", count_and_return("info"));
+#if UT_LOG_LEVEL >= UT_LOG_LEVEL_INFO
     UT_ASSERT(g_call_count == 1);
+#else
+    UT_ASSERT(g_call_count == 0);
+#endif
 
-    UT_LOG("test_ut_log_active_macros_evaluate_args end\n");
+    g_call_count = 0;
+    UT_LOG_DEBUG("%s", count_and_return("debug"));
+#if UT_LOG_LEVEL >= UT_LOG_LEVEL_DEBUG
+    UT_ASSERT(g_call_count == 1);
+#else
+    UT_ASSERT(g_call_count == 0);
+#endif
+
+    UT_LOG("test_ut_log_macro_suppression_and_arg_evaluation end\n");
 }
 
 /**
  * @brief Verify active log macros handle multiple format specifiers correctly.
  *
- * @note Only UT_LOG_WARNING and UT_LOG_ERROR are exercised here because those
- *       are the only macros active at the default UT_LOG_LEVEL_WARNING (2).
- *       UT_LOG_INFO would silently expand to a no-op at this level.
+ * All four macros are exercised; suppressed ones expand to no-ops so the
+ * test is safe at any configured UT_LOG_LEVEL.
  */
 static void test_ut_log_format_specifiers(void)
 {
     UT_LOG("test_ut_log_format_specifiers\n");
 
-    UT_LOG_WARNING("int=%d str=%s float=%.2f", 42, "hello", 3.14f);
+    UT_LOG_ERROR("int=%d str=%s float=%.2f", 42, "hello", 3.14f);
     UT_LOG_WARNING("hex=0x%x unsigned=%u", 0xDEADu, 255u);
-    UT_LOG_ERROR("long=%ld char=%c", 123456L, 'Z');
+    UT_LOG_INFO("long=%ld char=%c", 123456L, 'Z');
+    UT_LOG_DEBUG("ptr=%p", (void *)0);
 
     UT_LOG("test_ut_log_format_specifiers end\n");
 }
@@ -168,7 +179,6 @@ void register_log_functions(void)
     gpLogSuite2 = UT_add_suite("ut-log - macro suppression tests", NULL, NULL);
     assert(gpLogSuite2 != NULL);
 
-    UT_add_test(gpLogSuite2, "log active macros at WARNING level",    test_ut_log_active_macros_at_warning_level);
-    UT_add_test(gpLogSuite2, "log DEBUG suppressed at WARNING level", test_ut_log_debug_suppressed_at_warning_level);
-    UT_add_test(gpLogSuite2, "log active macros evaluate arguments",  test_ut_log_active_macros_evaluate_args);
+    UT_add_test(gpLogSuite2, "log active macros smoke test",             test_ut_log_active_macros_smoke_test);
+    UT_add_test(gpLogSuite2, "log macro suppression and arg evaluation",  test_ut_log_macro_suppression_and_arg_evaluation);
 }

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -61,13 +61,8 @@ static void test_ut_log_level_constant_values(void)
 }
 
 /**
- * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_WARNING (2) when not
- *        overridden at compile time.
- *
- * @note This test assumes the binary was compiled WITHOUT a -DUT_LOG_LEVEL override.
- *       If the suite is built with a different level this assertion will fail by design.
- *       Because ut_log.h has an include guard, only the level baked into this binary
- *       can be exercised; separate builds are required to cover other levels.
+ * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_WARNING (2)
+ *        when not overridden at compile time.
  */
 static void test_ut_log_default_level(void)
 {
@@ -97,16 +92,16 @@ static void test_ut_log_active_macros_at_warning_level(void)
 }
 
 /**
- * @brief Verify that UT_LOG_DEBUG is suppressed at the default WARNING level.
+ * @brief Verify that UT_LOG_DEBUG is suppressed at the default WARNING level
+ *        and that its arguments are NOT evaluated.
  *
- * When UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG the macro is redefined to expand to
- * do { } while (0), so any argument expressions must NOT be evaluated.
+ * UT_LOG_DEBUG expands to:
+ *     do { if (UT_LOG_ENABLED(DEBUG)) UT_logPrefix(..., arg); } while(0)
  *
- * @note This test is only meaningful when the binary is compiled at the default
- *       UT_LOG_LEVEL_WARNING (2). Overriding the level at build time (e.g.
- *       -DUT_LOG_LEVEL=4) will cause the macro to remain active and the
- *       g_call_count assertion below will fail. Due to ut_log.h's include guard,
- *       only one log level can be tested per binary.
+ * When the level check is false the entire if-body is skipped, so
+ * count_and_return() is never called.
+ *
+ * @note Assumes the binary is compiled at the default WARNING (2) level.
  */
 static void test_ut_log_debug_suppressed_at_warning_level(void)
 {
@@ -115,8 +110,7 @@ static void test_ut_log_debug_suppressed_at_warning_level(void)
     g_call_count = 0;
     UT_LOG_DEBUG("%s", count_and_return("debug suppressed test"));
 
-    /* At default level (WARNING=2) < DEBUG(4), so the macro is a no-op and
-     * count_and_return() must NOT have been called. */
+    /* The if-body was not reached, so count_and_return() was not called. */
     UT_ASSERT(g_call_count == 0);
 
     UT_LOG("test_ut_log_debug_suppressed_at_warning_level end\n");

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -18,8 +18,6 @@
  */
 
 /* Standard Libraries */
-#include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 
 /* Module Includes */
@@ -29,10 +27,12 @@
 static UT_test_suite_t *gpLogSuite = NULL;
 static UT_test_suite_t *gpLogSuite2 = NULL;
 
-/* Helper used to detect whether a macro argument is evaluated (i.e. not suppressed). */
+/* Helper used to detect whether a macro argument is evaluated (i.e. not suppressed).
+ * Marked unused to suppress -Wunused-function when all log macros that reference it
+ * are suppressed by a low UT_LOG_LEVEL (e.g. UT_LOG_LEVEL_NONE). */
 static int g_call_count = 0;
 
-static const char *count_and_return(const char *msg)
+static __attribute__((unused)) const char *count_and_return(const char *msg)
 {
     g_call_count++;
     return msg;
@@ -57,70 +57,81 @@ static void test_ut_log_level_constant_values(void)
     UT_ASSERT(UT_LOG_LEVEL_WARNING < UT_LOG_LEVEL_INFO);
     UT_ASSERT(UT_LOG_LEVEL_INFO    < UT_LOG_LEVEL_DEBUG);
 
-    UT_LOG("test_ut_log_level_constant_values passed\n");
+    UT_LOG("test_ut_log_level_constant_values end\n");
 }
 
 /**
- * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_INFO (3) when not
+ * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_WARNING (2) when not
  *        overridden at compile time.
+ *
+ * @note This test assumes the binary was compiled WITHOUT a -DUT_LOG_LEVEL override.
+ *       If the suite is built with a different level this assertion will fail by design.
+ *       Because ut_log.h has an include guard, only the level baked into this binary
+ *       can be exercised; separate builds are required to cover other levels.
  */
 static void test_ut_log_default_level(void)
 {
     UT_LOG("test_ut_log_default_level\n");
 
-    UT_ASSERT(UT_LOG_LEVEL == UT_LOG_LEVEL_INFO);
+    UT_ASSERT(UT_LOG_LEVEL == UT_LOG_LEVEL_WARNING);
 
-    UT_LOG("test_ut_log_default_level passed\n");
+    UT_LOG("test_ut_log_default_level end\n");
 }
 
 /**
- * @brief Verify that the log macros which are active at the default INFO level
- *        (UT_LOG_INFO, UT_LOG_WARNING, UT_LOG_ERROR) execute without crashing
- *        and produce output.
+ * @brief Verify that the log macros which are active at the default WARNING level
+ *        (UT_LOG_WARNING, UT_LOG_ERROR) execute without crashing and produce output.
+ *
+ * @note At the default UT_LOG_LEVEL_WARNING (2), UT_LOG_INFO and UT_LOG_DEBUG are
+ *       suppressed and therefore not exercised here.
  */
-static void test_ut_log_active_macros_at_info_level(void)
+static void test_ut_log_active_macros_at_warning_level(void)
 {
-    UT_LOG("test_ut_log_active_macros_at_info_level\n");
+    UT_LOG("test_ut_log_active_macros_at_warning_level\n");
 
-    /* These should all expand to real calls at default UT_LOG_LEVEL = INFO */
+    /* These should all expand to real calls at default UT_LOG_LEVEL = WARNING */
     UT_LOG_ERROR("error macro test: value=%d", 1);
     UT_LOG_WARNING("warning macro test: value=%d", 2);
-    UT_LOG_INFO("info macro test: value=%d", 3);
 
-    UT_LOG("test_ut_log_active_macros_at_info_level passed\n");
+    UT_LOG("test_ut_log_active_macros_at_warning_level end\n");
 }
 
 /**
- * @brief Verify that UT_LOG_DEBUG is suppressed at the default INFO level.
+ * @brief Verify that UT_LOG_DEBUG is suppressed at the default WARNING level.
  *
  * When UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG the macro is redefined to expand to
- * nothing, so any argument expressions must NOT be evaluated.
+ * do { } while (0), so any argument expressions must NOT be evaluated.
+ *
+ * @note This test is only meaningful when the binary is compiled at the default
+ *       UT_LOG_LEVEL_WARNING (2). Overriding the level at build time (e.g.
+ *       -DUT_LOG_LEVEL=4) will cause the macro to remain active and the
+ *       g_call_count assertion below will fail. Due to ut_log.h's include guard,
+ *       only one log level can be tested per binary.
  */
-static void test_ut_log_debug_suppressed_at_info_level(void)
+static void test_ut_log_debug_suppressed_at_warning_level(void)
 {
-    UT_LOG("test_ut_log_debug_suppressed_at_info_level\n");
+    UT_LOG("test_ut_log_debug_suppressed_at_warning_level\n");
 
     g_call_count = 0;
     UT_LOG_DEBUG("%s", count_and_return("debug suppressed test"));
 
-    /* At default level (INFO=3) < DEBUG(4), so the macro is a no-op and
+    /* At default level (WARNING=2) < DEBUG(4), so the macro is a no-op and
      * count_and_return() must NOT have been called. */
     UT_ASSERT(g_call_count == 0);
 
-    UT_LOG("test_ut_log_debug_suppressed_at_info_level passed\n");
+    UT_LOG("test_ut_log_debug_suppressed_at_warning_level end\n");
 }
 
 /**
  * @brief Verify that the active macros do not suppress their arguments at
- *        the default INFO level (INFO, WARNING, ERROR arguments are evaluated).
+ *        the default WARNING level (WARNING, ERROR arguments are evaluated).
+ *
+ * @note At the default UT_LOG_LEVEL_WARNING (2), UT_LOG_INFO is suppressed so
+ *       its arguments are NOT evaluated.
  */
 static void test_ut_log_active_macros_evaluate_args(void)
 {
     UT_LOG("test_ut_log_active_macros_evaluate_args\n");
-
-    g_call_count = 0;
-    UT_LOG_INFO("%s", count_and_return("info arg"));
-    UT_ASSERT(g_call_count == 1);
 
     g_call_count = 0;
     UT_LOG_WARNING("%s", count_and_return("warning arg"));
@@ -130,21 +141,25 @@ static void test_ut_log_active_macros_evaluate_args(void)
     UT_LOG_ERROR("%s", count_and_return("error arg"));
     UT_ASSERT(g_call_count == 1);
 
-    UT_LOG("test_ut_log_active_macros_evaluate_args passed\n");
+    UT_LOG("test_ut_log_active_macros_evaluate_args end\n");
 }
 
 /**
- * @brief Verify UT_LOG_INFO with multiple format specifiers works correctly.
+ * @brief Verify active log macros handle multiple format specifiers correctly.
+ *
+ * @note Only UT_LOG_WARNING and UT_LOG_ERROR are exercised here because those
+ *       are the only macros active at the default UT_LOG_LEVEL_WARNING (2).
+ *       UT_LOG_INFO would silently expand to a no-op at this level.
  */
 static void test_ut_log_format_specifiers(void)
 {
     UT_LOG("test_ut_log_format_specifiers\n");
 
-    UT_LOG_INFO("int=%d str=%s float=%.2f", 42, "hello", 3.14f);
-    UT_LOG_WARNING("hex=0x%x unsigned=%u", 0xDEAD, 255u);
+    UT_LOG_WARNING("int=%d str=%s float=%.2f", 42, "hello", 3.14f);
+    UT_LOG_WARNING("hex=0x%x unsigned=%u", 0xDEADu, 255u);
     UT_LOG_ERROR("long=%ld char=%c", 123456L, 'Z');
 
-    UT_LOG("test_ut_log_format_specifiers passed\n");
+    UT_LOG("test_ut_log_format_specifiers end\n");
 }
 
 void register_log_functions(void)
@@ -153,13 +168,13 @@ void register_log_functions(void)
     assert(gpLogSuite != NULL);
 
     UT_add_test(gpLogSuite, "log level constant values",    test_ut_log_level_constant_values);
-    UT_add_test(gpLogSuite, "log default level is INFO",    test_ut_log_default_level);
-    UT_add_test(gpLogSuite, "log format specifiers",        test_ut_log_format_specifiers);
+    UT_add_test(gpLogSuite, "log default level is WARNING",  test_ut_log_default_level);
+    UT_add_test(gpLogSuite, "log format specifiers",          test_ut_log_format_specifiers);
 
     gpLogSuite2 = UT_add_suite("ut-log - macro suppression tests", NULL, NULL);
     assert(gpLogSuite2 != NULL);
 
-    UT_add_test(gpLogSuite2, "log active macros at INFO level",       test_ut_log_active_macros_at_info_level);
-    UT_add_test(gpLogSuite2, "log DEBUG suppressed at INFO level",    test_ut_log_debug_suppressed_at_info_level);
+    UT_add_test(gpLogSuite2, "log active macros at WARNING level",    test_ut_log_active_macros_at_warning_level);
+    UT_add_test(gpLogSuite2, "log DEBUG suppressed at WARNING level", test_ut_log_debug_suppressed_at_warning_level);
     UT_add_test(gpLogSuite2, "log active macros evaluate arguments",  test_ut_log_active_macros_evaluate_args);
 }

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -169,8 +169,8 @@ static void test_ut_log_macro_suppression_and_arg_evaluation(void)
 /**
  * @brief Verify active log macros handle multiple format specifiers correctly.
  *
- * All four macros are exercised; suppressed ones expand to no-ops so the
- * test is safe at any configured UT_LOG_LEVEL.
+ * All four macros are exercised; depending on UT_LOG_LEVEL, output may be
+ * suppressed inside the wrapper functions.
  */
 static void test_ut_log_format_specifiers(void)
 {
@@ -187,14 +187,14 @@ static void test_ut_log_format_specifiers(void)
 void register_log_functions(void)
 {
     gpLogSuite = UT_add_suite("ut-log - level constant tests", NULL, NULL);
-    assert(gpLogSuite != NULL);
+    UT_ASSERT(gpLogSuite != NULL);
 
     UT_add_test(gpLogSuite, "log level constant values",    test_ut_log_level_constant_values);
     UT_add_test(gpLogSuite, "log default level is WARNING",  test_ut_log_default_level);
     UT_add_test(gpLogSuite, "log format specifiers",          test_ut_log_format_specifiers);
 
     gpLogSuite2 = UT_add_suite("ut-log - macro suppression tests", NULL, NULL);
-    assert(gpLogSuite2 != NULL);
+    UT_ASSERT(gpLogSuite2 != NULL);
 
     UT_add_test(gpLogSuite2, "log active macros smoke test",             test_ut_log_active_macros_smoke_test);
     UT_add_test(gpLogSuite2, "log macro suppression and arg evaluation",  test_ut_log_macro_suppression_and_arg_evaluation);

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -19,10 +19,14 @@
 
 /* Standard Libraries */
 #include <assert.h>
+#include <time.h>
 
 /* Module Includes */
 #include <ut.h>
 #include <ut_log.h>
+
+#define UT_TIME_DIFF_NS(start, end) \
+    (((end).tv_sec - (start).tv_sec) * 1000000000LL + ((end).tv_nsec - (start).tv_nsec))
 
 static UT_test_suite_t *gpLogSuite = NULL;
 static UT_test_suite_t *gpLogSuite2 = NULL;
@@ -84,19 +88,46 @@ static void test_ut_log_default_level(void)
 }
 
 /**
- * @brief Smoke-test all four level macros at the configured UT_LOG_LEVEL.
+ * @brief Smoke-test all four level macros and measure their call overhead.
  *
- * Active macros produce output; suppressed macros expand to a no-op.
+ * Each macro is timed individually using CLOCK_MONOTONIC; the elapsed
+ * nanoseconds are printed via UT_LOG immediately after each call.
+ * Active macros (at the configured UT_LOG_LEVEL) perform a full
+ * format+file-write cycle; suppressed macros return early inside the
+ * wrapper, so their overhead is expected to be significantly lower.
+ * UT_LOG is also timed as a baseline reference.
  * Verifies no crash regardless of the configured level.
  */
 static void test_ut_log_active_macros_smoke_test(void)
 {
+    struct timespec ts_start, ts_end;
+
     UT_LOG("test_ut_log_active_macros_smoke_test\n");
 
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
     UT_LOG_ERROR("error macro: value=%d", 1);
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    UT_LOG("UT_LOG_ERROR   overhead: %lld ns\n", (long long)UT_TIME_DIFF_NS(ts_start, ts_end));
+
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
     UT_LOG_WARNING("warning macro: value=%d", 2);
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    UT_LOG("UT_LOG_WARNING overhead: %lld ns\n", (long long)UT_TIME_DIFF_NS(ts_start, ts_end));
+
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
     UT_LOG_INFO("info macro: value=%d", 3);
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    UT_LOG("UT_LOG_INFO    overhead: %lld ns\n", (long long)UT_TIME_DIFF_NS(ts_start, ts_end));
+
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
     UT_LOG_DEBUG("debug macro: value=%d", 4);
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    UT_LOG("UT_LOG_DEBUG   overhead: %lld ns\n", (long long)UT_TIME_DIFF_NS(ts_start, ts_end));
+
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
+    UT_LOG("actual macro: value=%d", 5);
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    UT_LOG("UT_LOG overhead: %lld ns\n", (long long)UT_TIME_DIFF_NS(ts_start, ts_end));
 
     UT_LOG("test_ut_log_active_macros_smoke_test end\n");
 }
@@ -105,46 +136,32 @@ static void test_ut_log_active_macros_smoke_test(void)
  * @brief Verify argument evaluation for every level macro at the configured
  *        UT_LOG_LEVEL.
  *
- * For each macro, count_and_return() is expected to be called iff the macro
- * is active at compile time (i.e. UT_LOG_LEVEL >= that level).
- * Suppressed macros expand to do { } while(0) so their arguments are never
- * evaluated.
+ * The log macros delegate to wrapper functions (UT_logPrefix_info, etc.).
+ * Because C evaluates all function arguments before the call, macro arguments
+ * are ALWAYS evaluated regardless of the active UT_LOG_LEVEL.  The level
+ * guard inside the wrapper controls whether output is produced, not whether
+ * the arguments are evaluated.
  */
 static void test_ut_log_macro_suppression_and_arg_evaluation(void)
 {
     UT_LOG("test_ut_log_macro_suppression_and_arg_evaluation\n");
 
+    /* Arguments are always evaluated — count_and_return() is always called. */
     g_call_count = 0;
     UT_LOG_ERROR("%s", count_and_return("error"));
-#if UT_LOG_LEVEL >= UT_LOG_LEVEL_ERROR
     UT_ASSERT(g_call_count == 1);
-#else
-    UT_ASSERT(g_call_count == 0);
-#endif
 
     g_call_count = 0;
     UT_LOG_WARNING("%s", count_and_return("warning"));
-#if UT_LOG_LEVEL >= UT_LOG_LEVEL_WARNING
     UT_ASSERT(g_call_count == 1);
-#else
-    UT_ASSERT(g_call_count == 0);
-#endif
 
     g_call_count = 0;
     UT_LOG_INFO("%s", count_and_return("info"));
-#if UT_LOG_LEVEL >= UT_LOG_LEVEL_INFO
     UT_ASSERT(g_call_count == 1);
-#else
-    UT_ASSERT(g_call_count == 0);
-#endif
 
     g_call_count = 0;
     UT_LOG_DEBUG("%s", count_and_return("debug"));
-#if UT_LOG_LEVEL >= UT_LOG_LEVEL_DEBUG
     UT_ASSERT(g_call_count == 1);
-#else
-    UT_ASSERT(g_call_count == 0);
-#endif
 
     UT_LOG("test_ut_log_macro_suppression_and_arg_evaluation end\n");
 }

--- a/tests/src/ut_test_log.c
+++ b/tests/src/ut_test_log.c
@@ -1,0 +1,165 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Standard Libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/* Module Includes */
+#include <ut.h>
+#include <ut_log.h>
+
+static UT_test_suite_t *gpLogSuite = NULL;
+static UT_test_suite_t *gpLogSuite2 = NULL;
+
+/* Helper used to detect whether a macro argument is evaluated (i.e. not suppressed). */
+static int g_call_count = 0;
+
+static const char *count_and_return(const char *msg)
+{
+    g_call_count++;
+    return msg;
+}
+
+/**
+ * @brief Verify that the compile-time log level constants have the correct numeric values.
+ */
+static void test_ut_log_level_constant_values(void)
+{
+    UT_LOG("test_ut_log_level_constant_values\n");
+
+    UT_ASSERT(UT_LOG_LEVEL_NONE    == 0);
+    UT_ASSERT(UT_LOG_LEVEL_ERROR   == 1);
+    UT_ASSERT(UT_LOG_LEVEL_WARNING == 2);
+    UT_ASSERT(UT_LOG_LEVEL_INFO    == 3);
+    UT_ASSERT(UT_LOG_LEVEL_DEBUG   == 4);
+
+    /* Ordering sanity */
+    UT_ASSERT(UT_LOG_LEVEL_NONE    < UT_LOG_LEVEL_ERROR);
+    UT_ASSERT(UT_LOG_LEVEL_ERROR   < UT_LOG_LEVEL_WARNING);
+    UT_ASSERT(UT_LOG_LEVEL_WARNING < UT_LOG_LEVEL_INFO);
+    UT_ASSERT(UT_LOG_LEVEL_INFO    < UT_LOG_LEVEL_DEBUG);
+
+    UT_LOG("test_ut_log_level_constant_values passed\n");
+}
+
+/**
+ * @brief Verify that the default UT_LOG_LEVEL equals UT_LOG_LEVEL_INFO (3) when not
+ *        overridden at compile time.
+ */
+static void test_ut_log_default_level(void)
+{
+    UT_LOG("test_ut_log_default_level\n");
+
+    UT_ASSERT(UT_LOG_LEVEL == UT_LOG_LEVEL_INFO);
+
+    UT_LOG("test_ut_log_default_level passed\n");
+}
+
+/**
+ * @brief Verify that the log macros which are active at the default INFO level
+ *        (UT_LOG_INFO, UT_LOG_WARNING, UT_LOG_ERROR) execute without crashing
+ *        and produce output.
+ */
+static void test_ut_log_active_macros_at_info_level(void)
+{
+    UT_LOG("test_ut_log_active_macros_at_info_level\n");
+
+    /* These should all expand to real calls at default UT_LOG_LEVEL = INFO */
+    UT_LOG_ERROR("error macro test: value=%d", 1);
+    UT_LOG_WARNING("warning macro test: value=%d", 2);
+    UT_LOG_INFO("info macro test: value=%d", 3);
+
+    UT_LOG("test_ut_log_active_macros_at_info_level passed\n");
+}
+
+/**
+ * @brief Verify that UT_LOG_DEBUG is suppressed at the default INFO level.
+ *
+ * When UT_LOG_LEVEL < UT_LOG_LEVEL_DEBUG the macro is redefined to expand to
+ * nothing, so any argument expressions must NOT be evaluated.
+ */
+static void test_ut_log_debug_suppressed_at_info_level(void)
+{
+    UT_LOG("test_ut_log_debug_suppressed_at_info_level\n");
+
+    g_call_count = 0;
+    UT_LOG_DEBUG("%s", count_and_return("debug suppressed test"));
+
+    /* At default level (INFO=3) < DEBUG(4), so the macro is a no-op and
+     * count_and_return() must NOT have been called. */
+    UT_ASSERT(g_call_count == 0);
+
+    UT_LOG("test_ut_log_debug_suppressed_at_info_level passed\n");
+}
+
+/**
+ * @brief Verify that the active macros do not suppress their arguments at
+ *        the default INFO level (INFO, WARNING, ERROR arguments are evaluated).
+ */
+static void test_ut_log_active_macros_evaluate_args(void)
+{
+    UT_LOG("test_ut_log_active_macros_evaluate_args\n");
+
+    g_call_count = 0;
+    UT_LOG_INFO("%s", count_and_return("info arg"));
+    UT_ASSERT(g_call_count == 1);
+
+    g_call_count = 0;
+    UT_LOG_WARNING("%s", count_and_return("warning arg"));
+    UT_ASSERT(g_call_count == 1);
+
+    g_call_count = 0;
+    UT_LOG_ERROR("%s", count_and_return("error arg"));
+    UT_ASSERT(g_call_count == 1);
+
+    UT_LOG("test_ut_log_active_macros_evaluate_args passed\n");
+}
+
+/**
+ * @brief Verify UT_LOG_INFO with multiple format specifiers works correctly.
+ */
+static void test_ut_log_format_specifiers(void)
+{
+    UT_LOG("test_ut_log_format_specifiers\n");
+
+    UT_LOG_INFO("int=%d str=%s float=%.2f", 42, "hello", 3.14f);
+    UT_LOG_WARNING("hex=0x%x unsigned=%u", 0xDEAD, 255u);
+    UT_LOG_ERROR("long=%ld char=%c", 123456L, 'Z');
+
+    UT_LOG("test_ut_log_format_specifiers passed\n");
+}
+
+void register_log_functions(void)
+{
+    gpLogSuite = UT_add_suite("ut-log - level constant tests", NULL, NULL);
+    assert(gpLogSuite != NULL);
+
+    UT_add_test(gpLogSuite, "log level constant values",    test_ut_log_level_constant_values);
+    UT_add_test(gpLogSuite, "log default level is INFO",    test_ut_log_default_level);
+    UT_add_test(gpLogSuite, "log format specifiers",        test_ut_log_format_specifiers);
+
+    gpLogSuite2 = UT_add_suite("ut-log - macro suppression tests", NULL, NULL);
+    assert(gpLogSuite2 != NULL);
+
+    UT_add_test(gpLogSuite2, "log active macros at INFO level",       test_ut_log_active_macros_at_info_level);
+    UT_add_test(gpLogSuite2, "log DEBUG suppressed at INFO level",    test_ut_log_debug_suppressed_at_info_level);
+    UT_add_test(gpLogSuite2, "log active macros evaluate arguments",  test_ut_log_active_macros_evaluate_args);
+}


### PR DESCRIPTION
## Pull request overview

This PR mainly adds compile-time log level support and new tests for logging behavior, while also including a memory leak/double-free fix in the KVP merge path. In short: it improves logging control, strengthens test coverage, updates the docs, and bundles a small stability fix found during testing.

Main feature: 

- adds configurable UT_LOG_LEVEL handling through the build system and log wrappers/macros.
- Tests: introduces a new ut_test_log.c test suite and wires it into the test runner.
- Docs: updates README.md with usage and log-level details.
- Extra fix: resolves a memory-management issue in src/ut_kvp.c and updates LSAN suppressions.