### PR TITLE
Fix : gh #126 : Bound convert_dot_to_slash() to prevent output buffer overflow

### DIFF
--- a/src/ut_kvp.c
+++ b/src/ut_kvp.c
@@ -993,29 +993,20 @@ static bool str_to_bool(const char *string)
 
 static void convert_dot_to_slash(const char *key, char *output)
 {
-    if (strchr(key, '.'))
+    size_t i;
+
+    /* Copy at most UT_KVP_MAX_ELEMENT_SIZE - 1 characters so the NUL
+     * terminator always lands inside the caller's UT_KVP_MAX_ELEMENT_SIZE
+     * buffer, converting '.' path separators to '/' as we go. */
+    for (i = 0; i < UT_KVP_MAX_ELEMENT_SIZE - 1 && key[i] != '\0'; i++)
     {
-        for (int i = 0; i <= UT_KVP_MAX_ELEMENT_SIZE; i++)
-        {
-            char key_val = key[i];
-            if (key_val == '\0')
-            {
-                break;
-            }
-            if (key_val == '.')
-            {
-                output[i] = '/';
-            }
-            else
-            {
-                output[i] = key_val;
-            }
-        }
-        output[strlen(key)] = '\0';
+        output[i] = (key[i] == '.') ? '/' : key[i];
     }
-    else
+    output[i] = '\0';
+
+    if (key[i] != '\0')
     {
-        snprintf(output, UT_KVP_MAX_ELEMENT_SIZE, "%s", key);
+        UT_LOG_ERROR("Key exceeds UT_KVP_MAX_ELEMENT_SIZE [%d]; truncated", UT_KVP_MAX_ELEMENT_SIZE);
     }
 }
 

--- a/tests/src/ut_test_kvp.c
+++ b/tests/src/ut_test_kvp.c
@@ -558,6 +558,35 @@ void test_ut_kvp_string(void)
 
 }
 
+/*
+ * Regression test for gh #126 : an oversized dotted key must not overflow the
+ * internal UT_KVP_MAX_ELEMENT_SIZE conversion buffer in convert_dot_to_slash().
+ * The key is converted/truncated within bounds and the call fails safely
+ * (the truncated key matches no entry) instead of corrupting the stack.
+ */
+void test_ut_kvp_oversizedKey(void)
+{
+    char result_kvp[UT_KVP_MAX_ELEMENT_SIZE] = {0xff};
+    char oversized_key[(UT_KVP_MAX_ELEMENT_SIZE * 2) + 1];
+    ut_kvp_status_t status;
+    size_t i;
+
+    /* Build a dotted key longer than UT_KVP_MAX_ELEMENT_SIZE so the
+     * conversion path must truncate rather than overflow. */
+    for (i = 0; i < sizeof(oversized_key) - 1; i++)
+    {
+        oversized_key[i] = ((i % 8) == 7) ? '.' : 'a';
+    }
+    oversized_key[sizeof(oversized_key) - 1] = '\0';
+
+    UT_LOG_STEP("ut_kvp_getStringField() - Oversized dotted key must fail safely (gh #126)");
+    status = ut_kvp_getStringField(gpMainTestInstance, oversized_key, result_kvp, UT_KVP_MAX_ELEMENT_SIZE);
+    /* The truncated key cannot match a real entry; the only requirement is
+     * that the call returns (no buffer overflow / crash) with a failure. */
+    UT_ASSERT(status != UT_KVP_STATUS_SUCCESS);
+    UT_LOG("oversized key status[%d]", status);
+}
+
 void test_ut_kvp_dataByte( void )
 {
     int bytes_count = 0;
@@ -1458,6 +1487,7 @@ void register_kvp_functions( void )
     UT_add_test(gpKVPSuite2, "kvp uint16", test_ut_kvp_uint16);
     UT_add_test(gpKVPSuite2, "kvp bool", test_ut_kvp_bool);
     UT_add_test(gpKVPSuite2, "kvp string", test_ut_kvp_string);
+    UT_add_test(gpKVPSuite2, "kvp oversized key", test_ut_kvp_oversizedKey);
     UT_add_test(gpKVPSuite2, "kvp uint32", test_ut_kvp_uint32);
     UT_add_test(gpKVPSuite2, "kvp uint64", test_ut_kvp_uint64);
     UT_add_test(gpKVPSuite2, "kvp int8", test_ut_kvp_int8);


### PR DESCRIPTION
## Summary

Fixes #126.

`convert_dot_to_slash()` could write past the caller's 256-byte `output` buffer for long dotted keys — the loop bound was `i <= UT_KVP_MAX_ELEMENT_SIZE` (writing `output[256]`) and `output[strlen(key)] = '\0'` terminated at an arbitrary offset.

## Change

Rewrote the function to be bounded: it copies at most `UT_KVP_MAX_ELEMENT_SIZE - 1` characters, converts `.` → `/` inline, NUL-terminates within bounds, and logs an error when an over-long key is truncated. The dotted / non-dotted branches are unified — the result is identical for keys without dots.

This fixes every caller — `ut_kvp_getStringField()`, `ut_kvp_fieldPresent()`, `ut_kvp_getListCount()`, `ut_kvp_getDataBytes()`, the typed getters — and the new `ut_kvp_iterCreate()` in #123 at the root, rather than requiring each caller to length-check its key.

## Test plan

- [ ] Existing KVP test suite passes
- [ ] A dotted key of length >= `UT_KVP_MAX_ELEMENT_SIZE` is truncated and logged instead of overflowing the buffer
