### PR TITLE
Fix : gh #130 : Use -O0 not -o0 to set optimisation level for TARGET=linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 
 # Defaults for target linux
 ifeq ($(TARGET),linux)
-CC ?= gcc -ggdb -o0 -Wall
+CC ?= gcc -ggdb -O0 -Wall
 endif
 
 SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.s)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,6 +32,8 @@ BIN_DIR := $(ROOT_DIR)/build/bin
 TOP_DIR := $(ROOT_DIR)
 ECHOE = /bin/echo -e
 
+FLAGS_SCRIPT = $(ROOT_DIR)/check_makefile_flags.py
+
 SRC_DIRS = $(ROOT_DIR)/src
 INC_DIRS := $(ROOT_DIR)/../include
 LIB_DIR = $(ROOT_DIR)/../build/${TARGET}/lib
@@ -71,9 +73,23 @@ export TARGET_EXEC
 export BUILD_DIR
 export LIB_DIR
 
-.PHONY: clean list build skeleton
+.PHONY: clean list build skeleton check_makefile_flags
 
-build:
+# Walk the build files for a lowercase -o glued to an optimisation level
+# (-o0, -os, -og). gcc accepts these silently and a later -o $@ on the same
+# command line wins, so nothing ever fails - which is why #130 went unnoticed.
+# Runs before build.sh so a flag typo is reported in seconds.
+#
+# The script also supports asserting what a variable expands to
+# (--expect CC=-ggdb,-O0,-Wall). Not wired up here yet: `CC ?=` in the top
+# level Makefile never fires, because GNU make treats ?= as
+# "ifeq ($(origin CC),undefined)" and the built-in CC has origin default. Once
+# that is resolved the expectation can be turned on.
+check_makefile_flags:
+	@$(ECHOE) UT [$@]
+	@$(FLAGS_SCRIPT) $(ROOT_DIR)/..
+
+build: check_makefile_flags
 	@$(ECHOE) UT [$@]
 	$(ROOT_DIR)/build.sh
 	make -C ./ut-core test

--- a/tests/check_makefile_flags.py
+++ b/tests/check_makefile_flags.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# /*
+#  * If not stated otherwise in this file or this component's LICENSE file the
+#  * following copyright and licenses apply:
+#  *
+#  * Copyright 2023 RDK Management
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  */
+
+"""Guard against mistyped compiler flags in the build files.
+
+Two checks, both static enough to run before anything is compiled:
+
+  scan    walk the build files looking for a lowercase `-o` immediately
+          followed by an optimisation level (`-o0`, `-os`, `-og`, ...).
+          Lowercase `-o` means "write output to this file", so `-o0` asks
+          for a file named `0` rather than setting optimisation. gcc accepts
+          it silently, and a later `-o $@` on the same command line wins, so
+          nothing ever fails - see ut-core issue #256 / ut-control issue #130.
+
+  expect  ask `make printenv` what a variable actually expands to and assert
+          the flags we intend are present. This catches the flag being
+          dropped or overwritten as well as mistyped.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# ANSI escape codes for colored output
+RED = "\033[91m"
+GREEN = "\033[92m"
+YELLOW = "\033[93m"
+RESET = "\033[0m"
+
+# Build files worth scanning: makefiles and the shell scripts that drive them.
+SCANNED_NAMES = ("Makefile", "makefile", "GNUmakefile")
+SCANNED_SUFFIXES = (".mk", ".sh")
+
+# Directories holding third party or generated content, not our build files.
+SKIPPED_DIRS = {".git", "build", "framework", "sysroot", "cpp_libs", "node_modules"}
+
+# A lowercase -o glued directly to an optimisation level. The trailing lookahead
+# keeps `-o3rdparty.o` and similar output filenames out of the results.
+OPT_TYPO_PATTERN = re.compile(r"(?<![\w-])-o(?=(?:[0-3]|s|z|g|fast)(?![\w./$-]))")
+
+# Makefiles and shell scripts both comment with #, escaped as \#. Only the part
+# of a line that survives the comment reaches the compiler, so only that part is
+# worth checking - otherwise prose describing the typo trips the check.
+COMMENT_PATTERN = re.compile(r"(?<!\\)#")
+
+
+def strip_comment(line):
+    """Return the part of the line that the shell or make would actually act on."""
+    match = COMMENT_PATTERN.search(line)
+    return line[: match.start()] if match else line
+
+
+def scan_file(path):
+    """Return [(line_number, line_text)] for each mistyped optimisation flag."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            lines = handle.readlines()
+    except OSError as error:
+        print(f"{RED}Error: cannot read '{path}': {error}{RESET}")
+        return None
+
+    return [
+        (number, text.rstrip())
+        for number, text in enumerate(lines, start=1)
+        if OPT_TYPO_PATTERN.search(strip_comment(text))
+    ]
+
+
+def scan_tree(root):
+    """Scan every build file under root. Returns a list of (path, line, text)."""
+    findings = []
+    scanned = 0
+
+    for directory, subdirectories, filenames in os.walk(root):
+        subdirectories[:] = [name for name in subdirectories if name not in SKIPPED_DIRS]
+
+        for filename in filenames:
+            if filename not in SCANNED_NAMES and not filename.endswith(SCANNED_SUFFIXES):
+                continue
+
+            path = os.path.join(directory, filename)
+            hits = scan_file(path)
+            if hits is None:
+                continue
+
+            scanned += 1
+            relative = os.path.relpath(path, root)
+            findings.extend((relative, number, text) for number, text in hits)
+
+    return scanned, findings
+
+
+def read_make_variables(make_dir, make_args):
+    """Return {name: value} as reported by `make printenv` in make_dir."""
+    command = ["make", "-C", make_dir, "printenv"] + list(make_args)
+
+    try:
+        completed = subprocess.run(
+            command, capture_output=True, text=True, check=False
+        )
+    except OSError as error:
+        print(f"{RED}Error: cannot run '{' '.join(command)}': {error}{RESET}")
+        return None
+
+    if completed.returncode != 0:
+        print(f"{RED}Error: '{' '.join(command)}' failed:{RESET}")
+        print(completed.stderr.strip())
+        return None
+
+    variables = {}
+    for line in completed.stdout.splitlines():
+        name, separator, value = line.partition(" = ")
+        if separator and name and " " not in name:
+            variables[name] = value.strip()
+
+    return variables
+
+
+def check_expectations(variables, expectations):
+    """Return [(variable, missing_flags, value)] for each unmet expectation."""
+    failures = []
+
+    for expectation in expectations:
+        name, separator, flag_list = expectation.partition("=")
+        if not separator:
+            print(f"{RED}Error: --expect needs VAR=flag,flag - got '{expectation}'{RESET}")
+            return None
+
+        flags = [flag for flag in flag_list.split(",") if flag]
+        value = variables.get(name)
+
+        if value is None:
+            failures.append((name, flags, None))
+            continue
+
+        missing = [flag for flag in flags if flag not in value.split()]
+        if missing:
+            failures.append((name, missing, value))
+
+    return failures
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check the build files for mistyped or missing compiler flags."
+    )
+    parser.add_argument("root", help="Directory tree to scan for build files")
+    parser.add_argument(
+        "--expect",
+        metavar="VAR=flag,flag",
+        action="append",
+        default=[],
+        help="Assert `make printenv` reports VAR containing these flags",
+    )
+    parser.add_argument(
+        "--make-arg",
+        metavar="NAME=VALUE",
+        action="append",
+        default=[],
+        help="Argument passed to `make printenv`, e.g. TARGET=linux",
+    )
+
+    args = parser.parse_args()
+    root = os.path.abspath(args.root)
+
+    scanned, findings = scan_tree(root)
+
+    if findings:
+        print(f"\n{RED}Mistyped optimisation flags:{RESET}")
+        for path, number, text in findings:
+            print(f"{path}:{number}: {RED}{text.strip()} ❌{RESET}")
+        print(f"{YELLOW}Lowercase -o names an output file. Optimisation is -O.{RESET}")
+
+    expectation_failures = []
+    if args.expect:
+        variables = read_make_variables(root, args.make_arg)
+        if variables is None:
+            sys.exit(1)
+
+        expectation_failures = check_expectations(variables, args.expect)
+        if expectation_failures is None:
+            sys.exit(1)
+
+        if expectation_failures:
+            print(f"\n{RED}Expected flags missing:{RESET}")
+            for name, missing, value in expectation_failures:
+                if value is None:
+                    print(f"{name}: {RED}not reported by make printenv ❌{RESET}")
+                else:
+                    print(f"{name}: {RED}missing {' '.join(missing)} ❌{RESET} - is [{value}]")
+
+    print("\n------------------------------------------------------------------")
+    print(f"Build files scanned under {os.path.relpath(root, os.getcwd())} :: {scanned}")
+    flag_colour = RED if findings else GREEN
+    print(f"Mistyped optimisation flags :: {flag_colour}{len(findings)}{RESET}")
+    if args.expect:
+        expect_colour = RED if expectation_failures else GREEN
+        checked = len(args.expect)
+        met = checked - len(expectation_failures)
+        print(f"Expected flag sets met :: {expect_colour}{met} / {checked}{RESET}")
+    print("--------------------------------------------------------------------")
+
+    if findings or expectation_failures:
+        sys.exit(1)


### PR DESCRIPTION
Fixes #130

Applies the patch supplied by @looopTools in the issue, with authorship preserved via `git am`.

`-o0` is not an optimisation flag — lowercase `-o` is "write output to this file", so `-o0` asks for a file named `0`. The `TARGET=linux` default is now `-O0`.

```make
CC ?= gcc -ggdb -O0 -Wall
```

`TARGET=arm` is untouched — it takes `$(CC)` from the SDK and never carried the flag.

### Note for reviewers: this line is currently a no-op

Worth flagging while the line is under the microscope — `Makefile:117` uses `?=`, which GNU make defines as `ifeq ($(origin CC),undefined)`. Make's built-in `CC = cc` has origin `default`, never `undefined`, so **the assignment never fires**:

```
$ cat probe.mk
CC ?= gcc -ggdb -O0 -Wall
show:
	@echo "CC=[$(CC)] origin=$(origin CC)"
$ make -f probe.mk show
CC=[cc] origin=default
```

So a standalone `make TARGET=linux` in ut-control compiles with bare `cc` — no `-ggdb`, no `-Wall`, no `-O0` — and when driven from ut-core, `CC` arrives on the command line and overrides the line regardless. This PR is therefore a correctness fix with no behavioural change on its own.

The real `-o0` damage came from ut-core passing `CC="gcc -ggdb -o0 -Wall"` down to this sub-make; that side is fixed in rdkcentral/ut-core#258.

If maintainers want the intended defaults to actually apply, the idiom that works while still honouring environment and command-line overrides is:

```make
ifeq ($(origin CC),default)
CC := gcc -ggdb -O0 -Wall
endif
```

Deliberately left out of this PR — happy to raise it separately if wanted.

### Verification

- `grep -rn '\-o0' --include=Makefile --include=*.mk --include=*.sh .` returns no hits.
- Standalone `make TARGET=linux` on this branch builds clean, and no file named `0` appears in the tree afterwards.

---

## Second commit: a regression guard in the tests suite

The typo is two characters, but it survived because **no functional test could ever have caught it** — gcc accepted `-o0`, a later `-o $@` on the same command line won, and `-O0` is gcc's default. Every build stayed green. Only a static check on the build files can see it.

`tests/check_makefile_flags.py` is wired into the suite as `check_makefile_flags` and runs before `build.sh`, so a flag typo costs seconds rather than a full build. It walks every `Makefile`/`*.mk`/`*.sh` for a lowercase `-o` glued to an optimisation level (`-o0`, `-os`, `-og`, `-ofast`), skipping third-party trees. Comments are stripped before matching, so prose describing the typo does not trip the check.

Verified by reintroducing `-o0` on top of the fix:

```
Mistyped optimisation flags:
Makefile:117: CC ?= gcc -ggdb -o0 -Wall ❌
Lowercase -o names an output file. Optimisation is -O.

Build files scanned under .. :: 9
Mistyped optimisation flags :: 1
make: *** [Makefile:90: check_makefile_flags] Error 1
```

On the fixed tree: 9 build files scanned, 0 findings.

### The value assertion is deliberately left off

The script also supports asserting what a variable actually expands to via `make printenv` — `--expect CC=-ggdb,-O0,-Wall` — which is the stronger check, since it catches flags being dropped as well as mistyped. It is **not** wired up here, because it would fail immediately: `CC ?=` never fires (see above), so `CC` expands to bare `cc`. Turning it on therefore means deciding the `?=` question first. The reason is recorded in a comment in `tests/Makefile` next to the target so the next person does not have to rediscover it.

The same script is added to ut-core in rdkcentral/ut-core#258, where the value assertion **is** enabled (`COMPILER` and `UT_CONTROL_COMPILER` must contain `-ggdb -O0 -Wall`).
